### PR TITLE
[FE] - Conectar frontend con API para login de usuario

### DIFF
--- a/frontend/wallaclone/src/pages/LoginPage.tsx
+++ b/frontend/wallaclone/src/pages/LoginPage.tsx
@@ -1,52 +1,78 @@
-import { useState } from "react";
+import { useState, type SyntheticEvent } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import Footer from "../components/layout/Footer";
-
-const fakeUsers = [
-    { username: "sara", password: "123456" },
-    { username: "marian", password: "abcdef" },
-];
+import { loginUser } from "../services/authService";
 
 export default function LoginPage() {
     const navigate = useNavigate();
+
     const [username, setUsername] = useState("");
     const [password, setPassword] = useState("");
-    const [errors, setErrors] = useState<{ username?: string; password?: string; general?: string }>({});
+    const [isLoading, setIsLoading] = useState(false);
+    const [errors, setErrors] = useState<{
+        username?: string;
+        password?: string;
+        general?: string;
+    }>({});
 
-    const handleSubmit = (e: React.FormEvent) => {
-        e.preventDefault();
-        const newErrors: { username?: string; password?: string; general?: string } = {};
+    const validate = () => {
+        const newErrors: {
+            username?: string;
+            password?: string;
+            general?: string;
+        } = {};
 
-        // Validación: campos obligatorios
         if (!username.trim()) {
             newErrors.username = "El nombre de usuario es obligatorio";
         }
+
         if (!password) {
             newErrors.password = "La contraseña es obligatoria";
+        } else if (password.length < 6) {
+            newErrors.password = "La contraseña debe tener al menos 6 caracteres";
+        } else if (password.length > 64) {
+            newErrors.password = "La contraseña no puede tener más de 64 caracteres";
         }
 
-        // Si hay errores de campo, no seguimos
-        if (newErrors.username || newErrors.password) {
-            setErrors(newErrors);
+        setErrors(newErrors);
+        return Object.keys(newErrors).length === 0;
+    };
+
+    const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
+        e.preventDefault();
+
+        if (!validate()) {
             return;
         }
 
-        // Verificar credenciales contra datos falsos
-        const user = fakeUsers.find(
-            (u) => u.username === username.trim() && u.password === password
-        );
+        try {
+            setIsLoading(true);
+            setErrors({});
 
-        if (!user) {
-            setErrors({ general: "Usuario o contraseña incorrectos" });
-            return;
+            const data = await loginUser({
+                username: username.trim(),
+                password,
+            });
+
+            localStorage.setItem("token", data.token);
+
+            if (data.user) {
+                localStorage.setItem("user", JSON.stringify(data.user));
+            } else {
+                localStorage.setItem("user", username.trim());
+            }
+
+            navigate("/");
+        } catch (error) {
+            setErrors({
+                general:
+                    error instanceof Error
+                        ? error.message
+                        : "No se ha podido iniciar sesión",
+            });
+        } finally {
+            setIsLoading(false);
         }
-
-        // Simular guardar token/sesión
-        localStorage.setItem("token", "fake-token-" + user.username);
-        localStorage.setItem("user", user.username);
-
-        // Redirigir a la página principal
-        navigate("/");
     };
 
     return (
@@ -61,16 +87,17 @@ export default function LoginPage() {
                         Iniciar sesión
                     </h1>
 
-                    {/* Error general */}
                     {errors.general && (
                         <p className="text-red-500 text-sm text-center mb-4">
                             {errors.general}
                         </p>
                     )}
 
-                    {/* Campo: nombre de usuario */}
                     <div className="mb-4">
-                        <label htmlFor="username" className="block text-sm font-medium text-gray-700 mb-1">
+                        <label
+                            htmlFor="username"
+                            className="block text-sm font-medium text-gray-700 mb-1"
+                        >
                             Nombre de usuario
                         </label>
                         <input
@@ -79,7 +106,11 @@ export default function LoginPage() {
                             value={username}
                             onChange={(e) => {
                                 setUsername(e.target.value);
-                                setErrors((prev) => ({ ...prev, username: undefined, general: undefined }));
+                                setErrors((prev) => ({
+                                    ...prev,
+                                    username: undefined,
+                                    general: undefined,
+                                }));
                             }}
                             className={`w-full border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#00bba7] ${errors.username ? "border-red-500" : "border-gray-300"
                                 }`}
@@ -90,9 +121,11 @@ export default function LoginPage() {
                         )}
                     </div>
 
-                    {/* Campo: contraseña */}
                     <div className="mb-6">
-                        <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+                        <label
+                            htmlFor="password"
+                            className="block text-sm font-medium text-gray-700 mb-1"
+                        >
                             Contraseña
                         </label>
                         <input
@@ -101,8 +134,14 @@ export default function LoginPage() {
                             value={password}
                             onChange={(e) => {
                                 setPassword(e.target.value);
-                                setErrors((prev) => ({ ...prev, password: undefined, general: undefined }));
+                                setErrors((prev) => ({
+                                    ...prev,
+                                    password: undefined,
+                                    general: undefined,
+                                }));
                             }}
+                            minLength={6}
+                            maxLength={64}
                             className={`w-full border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#00bba7] ${errors.password ? "border-red-500" : "border-gray-300"
                                 }`}
                             placeholder="Tu contraseña"
@@ -112,21 +151,15 @@ export default function LoginPage() {
                         )}
                     </div>
 
-                    {/* Botón de login */}
                     <button
                         type="submit"
-                        className="w-full bg-[#00bba7] hover:bg-[#009689] text-white font-semibold py-2 rounded-md transition-colors text-sm"
+                        disabled={isLoading}
+                        className="w-full bg-[#00bba7] hover:bg-[#009689] disabled:bg-gray-300 disabled:cursor-not-allowed text-white font-semibold py-2 rounded-md transition-colors text-sm"
                     >
-                        Entrar
+                        {isLoading ? "Entrando..." : "Entrar"}
                     </button>
 
-                    {/* Enlaces */}
                     <div className="mt-4 text-center text-sm text-gray-600 space-y-2">
-                        <p>
-                            <Link to="/forgot-password" className="text-[#00bba7] hover:underline">
-                                ¿Olvidaste tu contraseña?
-                            </Link>
-                        </p>
                         <p>
                             ¿No tienes cuenta?{" "}
                             <Link to="/register" className="text-[#00bba7] hover:underline">

--- a/frontend/wallaclone/src/services/authService.ts
+++ b/frontend/wallaclone/src/services/authService.ts
@@ -6,6 +6,23 @@ type RegisterUserData = {
     password: string;
 };
 
+type LoginUserData = {
+    username: string;
+    password: string;
+};
+
+type AuthUser = {
+    id?: string;
+    username: string;
+    email?: string;
+};
+
+type LoginResponse = {
+    message?: string;
+    token: string;
+    user?: AuthUser;
+};
+
 export async function registerUser(userData: RegisterUserData) {
     const response = await fetch(`${API_BASE_URL}/auth/register`, {
         method: "POST",
@@ -19,6 +36,28 @@ export async function registerUser(userData: RegisterUserData) {
 
     if (!response.ok) {
         throw new Error(data?.message ?? "No se ha podido completar el registro");
+    }
+
+    return data;
+}
+
+export async function loginUser(userData: LoginUserData): Promise<LoginResponse> {
+    const response = await fetch(`${API_BASE_URL}/auth/login`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(userData),
+    });
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok) {
+        throw new Error(data?.message ?? "Usuario o contraseña incorrectos");
+    }
+
+    if (!data?.token) {
+        throw new Error("La respuesta de login no incluye token");
     }
 
     return data;


### PR DESCRIPTION
## Contexto

Este PR conecta el formulario de login del frontend con el endpoint de login del backend.

Relacionado con:

- Closes #48
- Continúa el trabajo iniciado en #47 

---

## Cambios realizados

- Se añade `loginUser` en `authService.ts`
- Se conecta `LoginPage.tsx` con `POST /auth/login`
- Se elimina la validación contra usuarios falsos
- Se guarda el `token` devuelto por la API en `localStorage`
- Se guarda la información básica del usuario en `localStorage`
- Se añade gestión de errores devueltos por la API
- Se mantiene la validación de contraseña:
  - mínimo 6 caracteres
  - máximo 64 caracteres
- Se añaden `minLength` y `maxLength` en el input de contraseña
- Se tipa el submit con `SyntheticEvent`
- Se extrae el tipo `LoginErrors` para evitar duplicación en la gestión de errores del formulario 

---

## Comprobaciones

- [x] `npm run build`