### PR TITLE
chore: clean backend error handling

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4,27 +4,29 @@ import { errorMiddleware } from './middlewares/errorMiddleware';
 import { webRouter } from './routes/webRoutes';
 
 export const app = express();
+
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 
-//health
-app.use('/health', (req, res) => {
+// Healthcheck
+app.use('/health', (_req, res) => {
   res.json({
-    info: 'Git Girls API up & running',
+    info: 'Git Girls API en funcionamiento',
   });
 });
 
-//Routes
+// Rutas
 app.use('/auth', authenticationRouter);
 app.use('/adverts', webRouter);
 
-//error MW
+// Middleware de errores
 app.use(errorMiddleware);
 
-//should this go in a serparte file? refactor?
 export const startHttpApi = () => {
-  const url = process.env.PORT || 3000;
-  app.listen(url, () => {
-    console.log('API up & running on port: ', url);
+  const port = process.env.PORT || 3000;
+
+  app.listen(port, () => {
+    console.log('API en funcionamiento en el puerto:', port);
   });
 };
+

--- a/backend/src/bin/www.ts
+++ b/backend/src/bin/www.ts
@@ -3,13 +3,13 @@ import 'dotenv/config';
 import mongoose from 'mongoose';
 import { startHttpApi } from '../app';
 
-//should this be refactored into a different file?
 const connectMongoDb = async () => {
   const url = process.env.MONGO_URI || 'mongodb://localhost:27017';
-  console.log(url);
-  console.log('Connecting to mongodb...');
+
+  // Mejor no imprimir la URI para evitar exponer credenciales en logs
+  console.log('Conectando a MongoDB...');
   await mongoose.connect(url);
-  console.log('mongodb connected =)');
+  console.log('MongoDB conectado');
 };
 
 const executeApp = async () => {
@@ -17,7 +17,7 @@ const executeApp = async () => {
     await connectMongoDb();
     startHttpApi();
   } catch (error) {
-    console.log('unable to start application: ', error);
+    console.log('No se ha podido iniciar la aplicación:', error);
     process.exit(1);
   }
 };

--- a/backend/src/controllers/authentication/logoutController.ts
+++ b/backend/src/controllers/authentication/logoutController.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 
-export const logoutController = async (req: Request, res: Response) => {
+export const logoutController = async (_req: Request, res: Response) => {
     res.status(200).json({
         message: 'La sesión se ha cerrado con éxito',
     });

--- a/backend/src/controllers/authentication/securityService.ts
+++ b/backend/src/controllers/authentication/securityService.ts
@@ -6,7 +6,7 @@ const getJWTSecret = () => {
   const jwtSecret = process.env.JWT_SECRET;
 
   if (!jwtSecret) {
-    throw new Error('JWT_SECRET is required in .env file');
+    throw new Error('JWT_SECRET no está configurado en las variables de entorno');
   }
 
   return jwtSecret;
@@ -46,11 +46,9 @@ export const securityService = {
       const data = jwt.verify(token, jwtSecret) as { userId: string };
 
       return data;
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'jwt.verify error';
-
-      throw new UnauthorizedError(`Error verifying JWT: ${errorMessage}`);
+    } catch {
+      // Para no exponer detalles internos del token
+      throw new UnauthorizedError('Token de autenticación inválido');
     }
   },
 };

--- a/backend/src/errors/domainError.ts
+++ b/backend/src/errors/domainError.ts
@@ -8,26 +8,32 @@ export class DomainError extends Error {
 
 export class EntityNotFoundError extends DomainError {
   readonly name = 'EntityNotFoundError';
+
   constructor(entity: string, id: string) {
-    super(`${entity} with id ${id} could not be found`);
+    super(`No se ha encontrado ${entity} con id ${id}`);
   }
 }
+
 export class BusinessConflictError extends DomainError {
   readonly name = 'BusinessConflictError';
-  constructor(message = 'conflict') {
+
+  constructor(message = 'Conflicto en la operación') {
     super(message);
   }
 }
+
 export class UnauthorizedError extends DomainError {
-  readonly name = 'UnauthorizedError';//401
-  constructor(message = 'unauthorized error') {
+  readonly name = 'UnauthorizedError';
+
+  constructor(message = 'No autorizado') {
     super(message);
   }
 }
 
 export class ForbiddenOperationError extends DomainError {
-  readonly name = 'ForbiddenOperationError';//403
-  constructor(message = 'operation not allowed') {
+  readonly name = 'ForbiddenOperationError';
+
+  constructor(message = 'Operación no permitida') {
     super(message);
   }
 }

--- a/backend/src/middlewares/authMiddleware.ts
+++ b/backend/src/middlewares/authMiddleware.ts
@@ -2,18 +2,18 @@ import { NextFunction, Request, Response } from 'express';
 import { UnauthorizedError } from '../errors/domainError';
 import { securityService } from '../controllers/authentication/securityService';
 
-export const authMiddleware = (req: Request, res: Response, next: NextFunction) => {
+export const authMiddleware = (req: Request, _res: Response, next: NextFunction) => {
   try {
     const authenticationHeader = req.headers.authorization; // Authorization: Bearer <token>
 
     if (!authenticationHeader) {
-      throw new UnauthorizedError('Authorization header missing');
+      throw new UnauthorizedError('Falta la cabecera de autorización');
     }
 
     const [scheme, token] = authenticationHeader.split(' ');
 
     if (scheme !== 'Bearer' || !token) {
-      throw new UnauthorizedError('Invalid authorization format');
+      throw new UnauthorizedError('Formato de autorización inválido');
     }
 
     const data = securityService.verifyJWT(token);

--- a/backend/src/middlewares/errorMiddleware.ts
+++ b/backend/src/middlewares/errorMiddleware.ts
@@ -5,28 +5,32 @@ import { DomainError } from '../errors/domainError';
 
 const ErrorStatusCodes: Record<string, number> = {
   EntityNotFoundError: status.NOT_FOUND, // 404
-
   BusinessConflictError: status.CONFLICT, // 409
-
   UnauthorizedError: status.UNAUTHORIZED, // 401
-
   ForbiddenOperationError: status.FORBIDDEN, // 403
 };
 
-export const errorMiddleware = (error: Error, req: Request, res: Response, next: NextFunction) => {
+export const errorMiddleware = (
+  error: Error,
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+) => {
   if (error instanceof DomainError) {
-    const statusCode = ErrorStatusCodes[error.name] || 500;
+    const statusCode = ErrorStatusCodes[error.name] || status.INTERNAL_SERVER_ERROR; // 500
     res.status(statusCode).json({ error: error.message });
-    return;
-
-  } else if (error instanceof z.ZodError) {
-    const errorMessage = "Datos inválidos";
-    res.status(status.BAD_REQUEST).json({ error: errorMessage });
     return;
   }
 
-  console.error(" [ERROR NO CONTROLADO]:", error);
+  if (error instanceof z.ZodError) {
+    res.status(status.BAD_REQUEST).json({ error: 'Datos inválidos' });
+    return;
+  }
+
+  console.error('[ERROR NO CONTROLADO]:', error);
+
+  // Las respuestas de error usan siempre la clave `error`.
   res.status(status.INTERNAL_SERVER_ERROR).json({
-    error: "Algo salió mal, inténtalo más tarde",
+    error: 'Algo salió mal, inténtalo más tarde',
   });
 };


### PR DESCRIPTION
## Contexto

Se hizo una pequeña limpieza del backend para mejorar la consistencia de mensajes y evitar warnings de parámetros no usados.

---

### Cambios realizados

- Se unifican las respuestas de error bajo la clave `error`
- Se mantiene `message` para respuestas correctas
- Se traducen mensajes pendientes que estaban en inglés
- Se evita exponer detalles internos de JWT al cliente
- Se quita el log de la URI de MongoDB para no exponer datos sensibles
- Se renombraron parámetros no utilizados como `_req`, `_res` o `_next`
- Se eliminaron logs internos

---

## Comprobaciones

- [x] `npm run build`