### PR TITLE
Feat/issue9 borrar un anuncio be

### DIFF
--- a/backend/eslint.config.cjs
+++ b/backend/eslint.config.cjs
@@ -30,7 +30,17 @@ module.exports = [
       },
     },
     rules: {
-      '@typescript-eslint/no-unused-vars': ['warn'],
+      'no-unused-vars': 'off',
+      'no-use-before-define': 'off',
+
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
       '@typescript-eslint/no-use-before-define': 'error',
       '@typescript-eslint/explicit-function-return-type': 'off',
 
@@ -40,9 +50,7 @@ module.exports = [
       'import/export': 'error',
 
       quotes: ['error', 'single', { avoidEscape: true }],
-      semi: ['error', 'always'],
-      'no-unused-vars': 'off',
-      'no-use-before-define': 'off',
+      semi: ['error', 'always']
     },
   },
   prettierConfig,

--- a/backend/eslint.config.cjs
+++ b/backend/eslint.config.cjs
@@ -50,7 +50,7 @@ module.exports = [
       'import/export': 'error',
 
       quotes: ['error', 'single', { avoidEscape: true }],
-      semi: ['error', 'always']
+      semi: ['error', 'always'],
     },
   },
   prettierConfig,

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { authenticationRouter } from './routes/authenticationRoutes';
 import { errorMiddleware } from './middlewares/errorMiddleware';
 import { webRouter } from './routes/webRoutes';
+import { notFoundMiddleware } from './middlewares/notFoundMiddleware';
 
 export const app = express();
 app.use(express.json());
@@ -17,6 +18,9 @@ app.use('/health', (req, res) => {
 //Routes
 app.use('/auth', authenticationRouter);
 app.use('/adverts', webRouter);
+
+//Not Found 404
+app.use(notFoundMiddleware);
 
 //error MW
 app.use(errorMiddleware);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,12 +1,15 @@
-import express from 'express';
-import { authenticationRouter } from './routes/authenticationRoutes';
-import { errorMiddleware } from './middlewares/errorMiddleware';
-import { webRouter } from './routes/webRoutes';
 import cors from 'cors';
+import express, { Request, Response } from 'express';
+import { errorMiddleware } from './middlewares/errorMiddleware';
+import { notFoundMiddleware } from './middlewares/notFoundMiddleware';
+import { authenticationRouter } from './routes/authenticationRoutes';
+import { webRouter } from './routes/webRoutes';
 
 export const app = express();
 
-//CORS middleware
+const port = process.env.PORT || 3000;
+
+// Middleware de CORS
 app.use(
   cors({
     origin: process.env.CORS_ORIGIN ?? 'http://localhost:5173',
@@ -16,23 +19,25 @@ app.use(
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 
-// Healthcheck
-app.use('/health', (_req, res) => {
+// Comprobación de estado de la API
+app.use('/health', (_req: Request, res: Response) => {
   res.json({
     info: 'Git Girls API en funcionamiento',
   });
 });
 
-// Rutas
+// Rutas principales
 app.use('/auth', authenticationRouter);
 app.use('/adverts', webRouter);
 
-// Middleware de errores
+// Ruta no encontrada
+app.use(notFoundMiddleware);
+
+
+// Middleware centralizado de errores
 app.use(errorMiddleware);
 
 export const startHttpApi = () => {
-  const port = process.env.PORT || 3000;
-
   app.listen(port, () => {
     console.log('API en funcionamiento en el puerto:', port);
   });

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,7 +2,6 @@ import express from 'express';
 import { authenticationRouter } from './routes/authenticationRoutes';
 import { errorMiddleware } from './middlewares/errorMiddleware';
 import { webRouter } from './routes/webRoutes';
-import { notFoundMiddleware } from './middlewares/notFoundMiddleware';
 
 export const app = express();
 app.use(express.json());
@@ -18,9 +17,6 @@ app.use('/health', (req, res) => {
 //Routes
 app.use('/auth', authenticationRouter);
 app.use('/adverts', webRouter);
-
-//Not Found 404
-app.use(notFoundMiddleware);
 
 //error MW
 app.use(errorMiddleware);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -33,7 +33,6 @@ app.use('/adverts', webRouter);
 // Ruta no encontrada
 app.use(notFoundMiddleware);
 
-
 // Middleware centralizado de errores
 app.use(errorMiddleware);
 

--- a/backend/src/controllers/products/AdvertInputValidator.ts
+++ b/backend/src/controllers/products/AdvertInputValidator.ts
@@ -1,12 +1,14 @@
-import * as z from 'zod';
 import { Types } from 'mongoose';
+import * as z from 'zod';
 
 const trimmedString = z.string().trim();
 
+// En creación de anuncio el precio debe ser mayor que 0
 const positivePrice = z.coerce.number().positive({
   error: 'El precio tiene que ser mayor a cero',
 });
 
+// En filtros permitimos 0, por ejemplo minPrice=0
 const nonNegativeNumber = z.coerce.number().nonnegative();
 
 const paginationValidator = {
@@ -14,12 +16,18 @@ const paginationValidator = {
   limit: z.coerce.number().int().positive().max(100).default(10),
 };
 
-const hasValidPriceRange = ({ minPrice, maxPrice }: { minPrice?: number; maxPrice?: number }) => {
+const hasValidPriceRange = ({
+  minPrice,
+  maxPrice,
+}: {
+  minPrice?: number;
+  maxPrice?: number;
+}) => {
   return minPrice === undefined || maxPrice === undefined || minPrice <= maxPrice;
 };
 
-const mongoIdSchema = z.string().refine(val => Types.ObjectId.isValid(val), {
-  message: 'El ID proporcionado no tiene un formato válido',
+const mongoIdSchema = z.string().refine((value) => Types.ObjectId.isValid(value), {
+  error: 'El ID proporcionado no tiene un formato válido',
 });
 
 export const createAdBodyValidator = z.object({

--- a/backend/src/controllers/products/AdvertInputValidator.ts
+++ b/backend/src/controllers/products/AdvertInputValidator.ts
@@ -1,4 +1,5 @@
 import * as z from 'zod';
+import { Types } from 'mongoose';
 
 const trimmedString = z.string().trim();
 
@@ -13,15 +14,13 @@ const paginationValidator = {
   limit: z.coerce.number().int().positive().max(100).default(10),
 };
 
-const hasValidPriceRange = ({
-  minPrice,
-  maxPrice,
-}: {
-  minPrice?: number;
-  maxPrice?: number;
-}) => {
+const hasValidPriceRange = ({ minPrice, maxPrice }: { minPrice?: number; maxPrice?: number }) => {
   return minPrice === undefined || maxPrice === undefined || minPrice <= maxPrice;
 };
+
+const mongoIdSchema = z.string().refine(val => Types.ObjectId.isValid(val), {
+  message: 'El ID proporcionado no tiene un formato válido',
+});
 
 export const createAdBodyValidator = z.object({
   name: trimmedString.min(2, {
@@ -46,3 +45,7 @@ export const getAdvertsQueryValidator = z
     error: 'El precio mínimo debe ser menor o igual que el precio máximo',
     path: ['minPrice'],
   });
+
+export const mongoIdValidator = z.object({
+  id: mongoIdSchema,
+});

--- a/backend/src/controllers/products/deleteAdController.ts
+++ b/backend/src/controllers/products/deleteAdController.ts
@@ -1,28 +1,35 @@
-import { NextFunction, Request, Response } from 'express';
-import { mongoIdValidator } from './AdvertInputValidator';
-import { Advert } from '../../models/Advert';
+import type { RequestHandler } from 'express';
 import {
   EntityNotFoundError,
   ForbiddenOperationError,
   UnauthorizedError,
 } from '../../errors/domainError';
+import { Advert } from '../../models/Advert';
+import { mongoIdValidator } from './AdvertInputValidator';
 
-export const deleteAdvertController = async (req: Request, res: Response, next: NextFunction) => {
+
+export const deleteAdvertController: RequestHandler = async (req, res, next) => {
   try {
     if (!req.user) {
       throw new UnauthorizedError('Usuario no autenticado');
     }
-    const { id } = mongoIdValidator.parse(req.params);
 
-    const advertToDelete = await Advert.findById(id);
-    if (!advertToDelete) {
+
+    const { id } = mongoIdValidator.parse(req.params);
+    const advert = await Advert.findById(id);
+
+    if (!advert) {
       throw new EntityNotFoundError('anuncio', id);
     }
-    if (advertToDelete.ownerId.toString() !== req.user.id) {
-      throw new ForbiddenOperationError('No tiene permisos para borrar este anuncio');
+
+    // Solo el usuario propietario puede borrar su propio anuncio
+    const isOwner = advert.ownerId.toString() === req.user.id;
+
+    if (!isOwner) {
+      throw new ForbiddenOperationError('No tienes permisos para borrar este anuncio');
     }
-    await advertToDelete.deleteOne();
-    //tendría que volver a comprobar acá que deletedAdvert !== null?
+
+    await advert.deleteOne();
 
     res.status(200).json({
       message: 'Anuncio borrado con éxito',

--- a/backend/src/controllers/products/deleteAdController.ts
+++ b/backend/src/controllers/products/deleteAdController.ts
@@ -7,13 +7,11 @@ import {
 import { Advert } from '../../models/Advert';
 import { mongoIdValidator } from './AdvertInputValidator';
 
-
 export const deleteAdvertController: RequestHandler = async (req, res, next) => {
   try {
     if (!req.user) {
       throw new UnauthorizedError('Usuario no autenticado');
     }
-
 
     const { id } = mongoIdValidator.parse(req.params);
     const advert = await Advert.findById(id);

--- a/backend/src/controllers/products/deleteAdController.ts
+++ b/backend/src/controllers/products/deleteAdController.ts
@@ -1,0 +1,33 @@
+import { NextFunction, Request, Response } from 'express';
+import { mongoIdValidator } from './AdvertInputValidator';
+import { Advert } from '../../models/Advert';
+import {
+  EntityNotFoundError,
+  ForbiddenOperationError,
+  UnauthorizedError,
+} from '../../errors/domainError';
+
+export const deleteAdvertController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    if (!req.user) {
+      throw new UnauthorizedError('Usuario no autenticado');
+    }
+    const { id } = mongoIdValidator.parse(req.params);
+
+    const advertToDelete = await Advert.findById(id);
+    if (!advertToDelete) {
+      throw new EntityNotFoundError('anuncio', id);
+    }
+    if (advertToDelete.ownerId.toString() !== req.user.id) {
+      throw new ForbiddenOperationError('No tiene permisos para borrar este anuncio');
+    }
+    await advertToDelete.deleteOne();
+    //tendría que volver a comprobar acá que deletedAdvert !== null?
+
+    res.status(200).json({
+      message: 'Anuncio borrado con éxito',
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/errors/domainError.ts
+++ b/backend/src/errors/domainError.ts
@@ -9,7 +9,7 @@ export class DomainError extends Error {
 export class EntityNotFoundError extends DomainError {
   readonly name = 'EntityNotFoundError';
   constructor(entity: string, id: string) {
-    super(`No se ha econtrado el ${entity} con id ${id}`);
+    super(`${entity} with id ${id} could not be found`);
   }
 }
 export class BusinessConflictError extends DomainError {

--- a/backend/src/errors/domainError.ts
+++ b/backend/src/errors/domainError.ts
@@ -9,7 +9,7 @@ export class DomainError extends Error {
 export class EntityNotFoundError extends DomainError {
   readonly name = 'EntityNotFoundError';
   constructor(entity: string, id: string) {
-    super(`${entity} with id ${id} could not be found`);
+    super(`No se ha econtrado el ${entity} con id ${id}`);
   }
 }
 export class BusinessConflictError extends DomainError {

--- a/backend/src/middlewares/authMiddleware.ts
+++ b/backend/src/middlewares/authMiddleware.ts
@@ -1,18 +1,19 @@
 import { NextFunction, Request, Response } from 'express';
-import { UnauthorizedError } from '../errors/domainError';
 import { securityService } from '../controllers/authentication/securityService';
+import { UnauthorizedError } from '../errors/domainError';
 
 export const authMiddleware = (req: Request, _res: Response, next: NextFunction) => {
   try {
-    const authenticationHeader = req.headers.authorization; // Authorization: Bearer <token>
+    // Formato esperado: Authorization: Bearer <token>
+    const authenticationHeader = req.headers.authorization;
 
     if (!authenticationHeader) {
       throw new UnauthorizedError('Falta la cabecera de autorización');
     }
 
-    const [scheme, token] = authenticationHeader.split(' ');
+    const [scheme, token, extra] = authenticationHeader.split(' ');
 
-    if (scheme !== 'Bearer' || !token) {
+    if (scheme !== 'Bearer' || !token || extra) {
       throw new UnauthorizedError('Formato de autorización inválido');
     }
 

--- a/backend/src/middlewares/errorMiddleware.ts
+++ b/backend/src/middlewares/errorMiddleware.ts
@@ -1,13 +1,13 @@
+import { NextFunction, Request, Response } from 'express';
 import status from 'http-status';
 import * as z from 'zod';
-import { NextFunction, Request, Response } from 'express';
 import { DomainError } from '../errors/domainError';
 
-const ErrorStatusCodes: Record<string, number> = {
-  EntityNotFoundError: status.NOT_FOUND, // 404
-  BusinessConflictError: status.CONFLICT, // 409
-  UnauthorizedError: status.UNAUTHORIZED, // 401
-  ForbiddenOperationError: status.FORBIDDEN, // 403
+const errorStatusCodes: Record<string, number> = {
+  EntityNotFoundError: status.NOT_FOUND,
+  BusinessConflictError: status.CONFLICT,
+  UnauthorizedError: status.UNAUTHORIZED,
+  ForbiddenOperationError: status.FORBIDDEN,
 };
 
 export const errorMiddleware = (
@@ -17,7 +17,9 @@ export const errorMiddleware = (
   _next: NextFunction
 ) => {
   if (error instanceof DomainError) {
-    const statusCode = ErrorStatusCodes[error.name] || status.INTERNAL_SERVER_ERROR; // 500
+    const statusCode =
+      errorStatusCodes[error.name] || status.INTERNAL_SERVER_ERROR;
+
     res.status(statusCode).json({ error: error.message });
     return;
   }
@@ -29,7 +31,7 @@ export const errorMiddleware = (
 
   console.error('[ERROR NO CONTROLADO]:', error);
 
-  // Las respuestas de error usan siempre la clave `error`.
+  // Respuesta genérica para no exponer detalles técnicos
   res.status(status.INTERNAL_SERVER_ERROR).json({
     error: 'Algo salió mal, inténtalo más tarde',
   });

--- a/backend/src/middlewares/notFoundMiddleware.ts
+++ b/backend/src/middlewares/notFoundMiddleware.ts
@@ -1,0 +1,7 @@
+import { Request, Response } from "express";
+
+export const notFoundMiddleware = (req:Request, res:Response) => {
+  res.status(404).json({
+    error: 'Ruta no encontrada',
+  });
+}

--- a/backend/src/middlewares/notFoundMiddleware.ts
+++ b/backend/src/middlewares/notFoundMiddleware.ts
@@ -1,7 +1,7 @@
-import { Request, Response } from "express";
+import type { RequestHandler } from 'express';
 
-export const notFoundMiddleware = (req:Request, res:Response) => {
+export const notFoundMiddleware: RequestHandler = (_req, res) => {
   res.status(404).json({
     error: 'Ruta no encontrada',
   });
-}
+};

--- a/backend/src/routes/webRoutes.ts
+++ b/backend/src/routes/webRoutes.ts
@@ -2,9 +2,12 @@ import express from 'express';
 import { createAdvertController } from '../controllers/products/createAdvertController';
 import { getAdsController } from '../controllers/products/getAdsController';
 import { authMiddleware } from '../middlewares/authMiddleware';
+import { deleteAdvertController } from '../controllers/products/deleteAdController';
+
 
 export const webRouter = express.Router();
 
 // Product/Ad Routes
 webRouter.post('/', authMiddleware, createAdvertController);
 webRouter.get('/', getAdsController);
+webRouter.delete('/:id', deleteAdvertController);

--- a/backend/src/routes/webRoutes.ts
+++ b/backend/src/routes/webRoutes.ts
@@ -4,10 +4,9 @@ import { getAdsController } from '../controllers/products/getAdsController';
 import { authMiddleware } from '../middlewares/authMiddleware';
 import { deleteAdvertController } from '../controllers/products/deleteAdController';
 
-
 export const webRouter = express.Router();
 
 // Product/Ad Routes
 webRouter.post('/', authMiddleware, createAdvertController);
 webRouter.get('/', getAdsController);
-webRouter.delete('/:id', deleteAdvertController);
+webRouter.delete('/:id', authMiddleware, deleteAdvertController);


### PR DESCRIPTION
## Feature: borrar anuncio

### Añadido
- Endpoint DELETE `/adverts/:id`
- Protección de ruta mediante `authMiddleware` y JWT
- Validación de ObjectId de MongoDB usando Zod
- Validación de ownership para permitir borrar anuncios solo al propietario

### Manejo de errores
- Devuelve 401 si el usuario no está autenticado
- Devuelve 403 si el usuario autenticado no es el dueño del anuncio
- Devuelve 404 si el anuncio no existe
- Devuelve 400 si el id del anuncio no tiene formato válido de MongoDB

### Testing realizado
Probados los siguientes casos:
- borrado exitoso
- borrado de anuncio inexistente
- borrado con id inválida
- borrado sin token
- borrado de anuncio por un usuario que no es el dueño

---

Actualización tras la revisión:
- Se registra `notFoundMiddleware` en `app.ts`, después de las rutas y antes de `errorMiddleware`
- Se ajusta `errorMiddleware` para mantener la respuesta de errores con la clave error
- Se mejora la validación del header Authorization en `authMiddleware`
- Se añade validación del id de MongoDB para DELETE `/adverts/:id`
- Se corrige la configuración de ESLint para permitir parámetros no usados con _