### PR TITLE
[FE] - Implementar listado de últimos anuncios en home

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,21 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
+# Dependencies
 node_modules/
+
+# Build outputs
 dist
 dist-ssr
+coverage/
+
+# Local files
 *.local
+
+# Environment variables
+.env
+.env.*
+!.env.example
 
 # Editor directories and files
 .vscode/*
@@ -22,5 +33,3 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-
-.env

--- a/frontend/wallaclone/src/components/adverts/AdvertCard.tsx
+++ b/frontend/wallaclone/src/components/adverts/AdvertCard.tsx
@@ -1,0 +1,99 @@
+import type { Advert } from "../../services/advertService";
+
+type AdvertCardProps = {
+    advert: Advert;
+};
+
+function getAdvertTypeLabel(isSale: boolean) {
+    return isSale ? "Se vende" : "Se busca";
+}
+
+function getAdvertStatusLabel(status: Advert["status"]) {
+    const statusLabels = {
+        AVAILABLE: "Disponible",
+        RESERVED: "Reservado",
+        SOLD: "Vendido",
+    };
+
+    return statusLabels[status] ?? status;
+}
+
+function getOwnerName(ownerId: Advert["ownerId"]) {
+    if (!ownerId || typeof ownerId === "string") {
+        return "Usuario";
+    }
+
+    return ownerId.username ?? "Usuario";
+}
+
+function AdvertCard({ advert }: AdvertCardProps) {
+    return (
+        <article className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md">
+            <div className="h-48 bg-gray-100">
+                {advert.image ? (
+                    <img
+                        src={advert.image}
+                        alt={advert.name}
+                        className="h-full w-full object-cover"
+                    />
+                ) : (
+                    <div className="flex h-full items-center justify-center text-sm text-gray-500">
+                        Sin imagen
+                    </div>
+                )}
+            </div>
+
+            <div className="space-y-4 p-5">
+                <div className="flex items-start justify-between gap-3">
+                    <div>
+                        <p className="text-xs font-semibold uppercase tracking-wide text-[#00bba7]">
+                            {getAdvertTypeLabel(advert.isSale)}
+                        </p>
+                        <h2 className="mt-1 line-clamp-2 text-xl font-bold text-gray-900">
+                            {advert.name}
+                        </h2>
+                    </div>
+
+                    <span className="rounded-full bg-[#00bba7]/10 px-3 py-1 text-xs font-semibold text-[#009689]">
+                        {getAdvertStatusLabel(advert.status)}
+                    </span>
+                </div>
+
+                <p className="line-clamp-3 text-sm leading-6 text-gray-600">
+                    {advert.description}
+                </p>
+
+                <div className="flex items-end justify-between gap-4">
+                    <div>
+                        <p className="text-xs text-gray-500">Publicado por</p>
+                        <p className="font-medium text-gray-800">
+                            {getOwnerName(advert.ownerId)}
+                        </p>
+                    </div>
+
+                    <p className="text-2xl font-bold text-gray-900">
+                        {new Intl.NumberFormat("es-ES", {
+                            style: "currency",
+                            currency: "EUR",
+                        }).format(advert.price)}
+                    </p>
+                </div>
+
+                {advert.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                        {advert.tags.map((tag) => (
+                            <span
+                                key={tag}
+                                className="rounded-full bg-gray-100 px-3 py-1 text-xs text-gray-600"
+                            >
+                                #{tag}
+                            </span>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </article>
+    );
+}
+
+export default AdvertCard;

--- a/frontend/wallaclone/src/components/adverts/AdvertCard.tsx
+++ b/frontend/wallaclone/src/components/adverts/AdvertCard.tsx
@@ -18,12 +18,8 @@ function getAdvertStatusLabel(status: Advert["status"]) {
     return statusLabels[status] ?? status;
 }
 
-function getOwnerName(ownerId: Advert["ownerId"]) {
-    if (!ownerId || typeof ownerId === "string") {
-        return "Usuario";
-    }
-
-    return ownerId.username ?? "Usuario";
+function getOwnerName(owner?: Advert["owner"]) {
+    return owner?.username ?? "Usuario";
 }
 
 function AdvertCard({ advert }: AdvertCardProps) {
@@ -67,7 +63,7 @@ function AdvertCard({ advert }: AdvertCardProps) {
                     <div>
                         <p className="text-xs text-gray-500">Publicado por</p>
                         <p className="font-medium text-gray-800">
-                            {getOwnerName(advert.ownerId)}
+                            {getOwnerName(advert.owner)}
                         </p>
                     </div>
 

--- a/frontend/wallaclone/src/pages/HomePage.tsx
+++ b/frontend/wallaclone/src/pages/HomePage.tsx
@@ -1,10 +1,71 @@
+import { useEffect, useState } from "react";
+import AdvertCard from "../components/adverts/AdvertCard";
+import { getLatestAdverts, type Advert } from "../services/advertService";
+
 function HomePage() {
+    const [adverts, setAdverts] = useState<Advert[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [errorMessage, setErrorMessage] = useState("");
+
+    useEffect(() => {
+        async function loadLatestAdverts() {
+            try {
+                const data = await getLatestAdverts();
+                setAdverts(data.content);
+            } catch (error) {
+                setErrorMessage(
+                    error instanceof Error
+                        ? error.message
+                        : "No se han podido cargar los anuncios",
+                );
+            } finally {
+                setIsLoading(false);
+            }
+        }
+
+        loadLatestAdverts();
+    }, []);
+
     return (
-        <div className="p-8">
-            <h1 className="text-3xl font-bold">Wallaclone</h1>
-            <p className="mt-2 text-gray-600">Compra y vende artículos de segunda mano</p>
-        </div>
-    )
+        <section className="min-h-full bg-gray-50 px-6 py-8">
+            <div className="mx-auto max-w-7xl">
+                <div className="mb-8">
+                    <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+                        Últimos anuncios publicados
+                    </h1>
+                    <p className="mt-2 text-base text-gray-600">
+                        Encuentra artículos de segunda mano o publica lo que ya no necesitas
+                    </p>
+                </div>
+
+                {isLoading && (
+                    <div className="rounded-2xl border border-gray-200 bg-white p-8 text-center text-gray-600 shadow-sm">
+                        Cargando anuncios...
+                    </div>
+                )}
+
+                {!isLoading && errorMessage && (
+                    <div className="rounded-2xl border border-red-200 bg-red-50 p-6 text-center text-red-700">
+                        {errorMessage}
+                    </div>
+                )}
+
+                {!isLoading && !errorMessage && adverts.length === 0 && (
+                    <div className="rounded-2xl border border-gray-200 bg-white p-8 text-center text-gray-600 shadow-sm">
+                        Todavía no hay anuncios publicados
+                    </div>
+                )}
+
+                {!isLoading && !errorMessage && adverts.length > 0 && (
+                    <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                        {adverts.map((advert) => (
+                            <AdvertCard key={advert.id ?? advert._id} advert={advert} />
+                        ))}
+                    </div>
+                )}
+            </div>
+        </section>
+    );
 }
 
-export default HomePage
+export default HomePage;

--- a/frontend/wallaclone/src/pages/HomePage.tsx
+++ b/frontend/wallaclone/src/pages/HomePage.tsx
@@ -59,7 +59,7 @@ function HomePage() {
                 {!isLoading && !errorMessage && adverts.length > 0 && (
                     <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
                         {adverts.map((advert) => (
-                            <AdvertCard key={advert.id ?? advert._id} advert={advert} />
+                            <AdvertCard key={advert.id} advert={advert} />
                         ))}
                     </div>
                 )}

--- a/frontend/wallaclone/src/services/advertService.ts
+++ b/frontend/wallaclone/src/services/advertService.ts
@@ -1,0 +1,45 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:3000";
+
+type AdvertOwner =
+    | string
+    | {
+        _id?: string;
+        id?: string;
+        username?: string;
+    };
+
+export type Advert = {
+    _id: string;
+    id?: string;
+    name: string;
+    description: string;
+    price: number;
+    isSale: boolean;
+    image: string;
+    tags: string[];
+    status: "AVAILABLE" | "RESERVED" | "SOLD";
+    ownerId?: AdvertOwner;
+    createdAt?: string;
+    updatedAt?: string;
+};
+
+type GetAdvertsResponse = {
+    content: Advert[];
+    total: number;
+    page: number;
+    limit: number;
+};
+
+export async function getLatestAdverts(): Promise<GetAdvertsResponse> {
+    const response = await fetch(`${API_BASE_URL}/adverts?limit=12&page=1`);
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok) {
+        throw new Error(
+            data?.message ?? data?.error ?? "No se han podido cargar los anuncios",
+        );
+    }
+
+    return data;
+}

--- a/frontend/wallaclone/src/services/advertService.ts
+++ b/frontend/wallaclone/src/services/advertService.ts
@@ -1,16 +1,7 @@
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:3000";
 
-type AdvertOwner =
-    | string
-    | {
-        _id?: string;
-        id?: string;
-        username?: string;
-    };
-
 export type Advert = {
-    _id: string;
-    id?: string;
+    id: string;
     name: string;
     description: string;
     price: number;
@@ -18,9 +9,11 @@ export type Advert = {
     image: string;
     tags: string[];
     status: "AVAILABLE" | "RESERVED" | "SOLD";
-    ownerId?: AdvertOwner;
-    createdAt?: string;
-    updatedAt?: string;
+    ownerId: string;
+    owner?: {
+        id: string;
+        username?: string;
+    };
 };
 
 type GetAdvertsResponse = {


### PR DESCRIPTION
## Descripción

Implementa el listado de últimos anuncios publicados en la home.

## Cambios realizados

- Añadido servicio para obtener los últimos anuncios desde el backend.
- Añadido componente `AdvertCard` para mostrar la información básica de cada anuncio.
- Actualizada la home para mostrar estado de carga, error, listado de anuncios y estado vacío.

---

## Comprobaciones

- [x] Frontend levantado en `http://localhost:5173`
- [x] Backend levantado en `http://localhost:3000`
- [x] Comprobada petición `GET /adverts?limit=12&page=1` sin error de CORS
- [x] Comprobado estado vacío cuando no hay anuncios publicados
- [x] `npm run build`
- [x] `npm run lint`