### PR TITLE
chore: config CORS for frontend request

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,3 +3,5 @@ PORT=3000
 MONGO_URI=mongodb+srv://uri
 
 JWT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxx
+
+CORS_ORIGIN=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,4 +4,4 @@ MONGO_URI=mongodb+srv://uri
 
 JWT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxx
 
-CORS_ORIGIN=
+CORS_ORIGIN=http://localhost:5173

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,10 +19,12 @@
       },
       "devDependencies": {
         "@types/bcrypt": "^6.0.0",
+        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/node": "^25.6.0",
         "@typescript-eslint/eslint-plugin": "^8.58.2",
         "@typescript-eslint/parser": "^8.58.2",
+        "cors": "^2.8.6",
         "esbuild": "^0.28.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.4",
@@ -797,6 +799,16 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2041,6 +2053,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cross-spawn": {
@@ -4520,6 +4550,16 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@types/jsonwebtoken": "^9.0.10",
         "bcrypt": "^6.0.0",
+        "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "http-status": "^2.1.0",
@@ -24,7 +25,6 @@
         "@types/node": "^25.6.0",
         "@typescript-eslint/eslint-plugin": "^8.58.2",
         "@typescript-eslint/parser": "^8.58.2",
-        "cors": "^2.8.6",
         "esbuild": "^0.28.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.4",
@@ -2059,7 +2059,6 @@
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -4560,7 +4559,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,10 +24,12 @@
   },
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/node": "^25.6.0",
     "@typescript-eslint/eslint-plugin": "^8.58.2",
     "@typescript-eslint/parser": "^8.58.2",
+    "cors": "^2.8.6",
     "esbuild": "^0.28.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@types/jsonwebtoken": "^9.0.10",
     "bcrypt": "^6.0.0",
+    "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "http-status": "^2.1.0",
@@ -29,7 +30,6 @@
     "@types/node": "^25.6.0",
     "@typescript-eslint/eslint-plugin": "^8.58.2",
     "@typescript-eslint/parser": "^8.58.2",
-    "cors": "^2.8.6",
     "esbuild": "^0.28.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,11 +2,16 @@ import express from 'express';
 import { authenticationRouter } from './routes/authenticationRoutes';
 import { errorMiddleware } from './middlewares/errorMiddleware';
 import { webRouter } from './routes/webRoutes';
+import cors from 'cors'
 
 export const app = express();
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
+
+app.use(cors({
+origin: process.env.CORS_ORIGIN ?? 'http://localhost:5173/',
+}));
 
 // Healthcheck
 app.use('/health', (_req, res) => {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,16 +2,19 @@ import express from 'express';
 import { authenticationRouter } from './routes/authenticationRoutes';
 import { errorMiddleware } from './middlewares/errorMiddleware';
 import { webRouter } from './routes/webRoutes';
-import cors from 'cors'
+import cors from 'cors';
 
 export const app = express();
 
+//CORS middleware
+app.use(
+  cors({
+    origin: process.env.CORS_ORIGIN ?? 'http://localhost:5173/',
+  })
+);
+
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
-
-app.use(cors({
-origin: process.env.CORS_ORIGIN ?? 'http://localhost:5173/',
-}));
 
 // Healthcheck
 app.use('/health', (_req, res) => {
@@ -34,4 +37,3 @@ export const startHttpApi = () => {
     console.log('API en funcionamiento en el puerto:', port);
   });
 };
-

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -9,7 +9,7 @@ export const app = express();
 //CORS middleware
 app.use(
   cors({
-    origin: process.env.CORS_ORIGIN ?? 'http://localhost:5173/',
+    origin: process.env.CORS_ORIGIN ?? 'http://localhost:5173',
   })
 );
 


### PR DESCRIPTION
### Configurar CORS para permitir peticiones del frontend local
#### Contexto
El frontend no puede consumir la API localmente desde el navegador aunque el backend responda correctamente y bloquea la comprobación completa de integración frontend + backend en local.

#### Cambios Realizados
- Configuración de CORS en Backen:
   - Se instaló cors ```npm install cors -D @types/cors```
   - Se agrego variable de entorno CORS_ORIGIN
   - Se implemento CORS middleware en la app.ts antes de las rutas

#### Pruebas Realizadas
- [x] **Build:** ```npm run build``` finalizado con éxito.
- [x] **Runtime:** El servidor inicia correctamente con el nuevo middleware.
- [x] **Postman**: Verificado headers Access-Control-Allow-Origin incluido en respuesta
- [x] **Config**: Verificada la lectura de CORS_ORIGIN desde variables de entorno.v.

#### Notas Adicionales
Dado que el frontend aún está en proceso de integración, la validación se ha centrado en la correcta carga del middleware y la integridad del build de TypeScript. La prueba definitiva se realizará en el siguiente paso de integración UI.