### PR TITLE
fix: unify advert response contract

### DIFF
--- a/backend/src/controllers/products/advertResponseMapper.ts
+++ b/backend/src/controllers/products/advertResponseMapper.ts
@@ -1,0 +1,51 @@
+type ObjectIdLike = {
+    toString: () => string;
+};
+
+type PopulatedOwner = {
+    _id: ObjectIdLike | string;
+    username?: string;
+};
+
+type AdvertResponseSource = {
+    _id: ObjectIdLike | string;
+    name: string;
+    description: string;
+    price: number;
+    isSale: boolean;
+    image: string;
+    tags: string[];
+    ownerId: ObjectIdLike | string | PopulatedOwner;
+    status: string;
+};
+
+const hasId = (value: unknown): value is PopulatedOwner => {
+    return typeof value === 'object' && value !== null && '_id' in value;
+};
+
+const getIdAsString = (value: ObjectIdLike | string | PopulatedOwner) => {
+    return hasId(value) ? value._id.toString() : value.toString();
+};
+
+export const mapAdvertToResponse = (advert: AdvertResponseSource) => {
+    const ownerId = advert.ownerId;
+
+    return {
+        id: advert._id.toString(),
+        name: advert.name,
+        description: advert.description,
+        price: advert.price,
+        isSale: advert.isSale,
+        image: advert.image,
+        tags: advert.tags,
+        ownerId: getIdAsString(ownerId),
+        owner:
+            hasId(ownerId) && ownerId.username
+                ? {
+                    id: getIdAsString(ownerId),
+                    username: ownerId.username,
+                }
+                : undefined,
+        status: advert.status,
+    };
+};

--- a/backend/src/controllers/products/createAdvertController.ts
+++ b/backend/src/controllers/products/createAdvertController.ts
@@ -2,6 +2,7 @@ import type { RequestHandler } from 'express';
 import { UnauthorizedError } from '../../errors/domainError';
 import { Advert } from '../../models/Advert';
 import { createAdBodyValidator } from './AdvertInputValidator';
+import { mapAdvertToResponse } from './advertResponseMapper';
 
 export const createAdvertController: RequestHandler = async (req, res, next) => {
   try {
@@ -24,17 +25,8 @@ export const createAdvertController: RequestHandler = async (req, res, next) => 
 
     const createdAdvert = await newAdvert.save();
 
-    // respuesta: datos anuncio + mensaje de éxito
     res.status(201).json({
-      id: createdAdvert._id,
-      name: createdAdvert.name,
-      description: createdAdvert.description,
-      price: createdAdvert.price,
-      isSale: createdAdvert.isSale,
-      image: createdAdvert.image,
-      tags: createdAdvert.tags,
-      ownerId: createdAdvert.ownerId,
-      status: createdAdvert.status,
+      ...mapAdvertToResponse(createdAdvert),
       message: 'Anuncio creado con éxito',
     });
   } catch (error) {

--- a/backend/src/controllers/products/getAdsController.ts
+++ b/backend/src/controllers/products/getAdsController.ts
@@ -1,14 +1,14 @@
-import { Request, Response, NextFunction } from 'express';
-import { QueryFilter } from 'mongoose';
+import type { RequestHandler } from 'express';
+import type { QueryFilter } from 'mongoose';
 import { Advert } from '../../models/Advert';
 import { escapeRegex } from '../../utils/stringUtils';
 import { getAdvertsQueryValidator } from './AdvertInputValidator';
+import { mapAdvertToResponse } from './advertResponseMapper';
 
-export const getAdsController = async (req: Request, res: Response, next: NextFunction) => {
+export const getAdsController: RequestHandler = async (req, res, next) => {
   try {
-    const { name, minPrice, maxPrice, tag, limit, page } = getAdvertsQueryValidator.parse(
-      req.query
-    );
+    const { name, minPrice, maxPrice, tag, limit, page } =
+      getAdvertsQueryValidator.parse(req.query);
 
     const skip = (page - 1) * limit;
 
@@ -24,22 +24,31 @@ export const getAdsController = async (req: Request, res: Response, next: NextFu
       searchQuery.tags = tag;
     }
 
-    if (minPrice !== undefined || maxPrice !== undefined) {
+    const hasPriceFilter = minPrice !== undefined || maxPrice !== undefined;
+
+    if (hasPriceFilter) {
       searchQuery.price = {};
-      if (minPrice !== undefined) searchQuery.price.$gte = minPrice;
-      if (maxPrice !== undefined) searchQuery.price.$lte = maxPrice;
+
+      if (minPrice !== undefined) {
+        searchQuery.price.$gte = minPrice;
+      }
+
+      if (maxPrice !== undefined) {
+        searchQuery.price.$lte = maxPrice;
+      }
     }
 
-    const advertList = await Advert.find(searchQuery)
-      .sort({ createdAt: -1 })
-      .skip(skip)
-      .limit(limit)
-      .populate('ownerId', 'username');
-
-    const totalAdverts = await Advert.countDocuments(searchQuery);
+    const [advertList, totalAdverts] = await Promise.all([
+      Advert.find(searchQuery)
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .populate('ownerId', 'username'),
+      Advert.countDocuments(searchQuery),
+    ]);
 
     res.status(200).json({
-      content: advertList,
+      content: advertList.map((advert) => mapAdvertToResponse(advert)),
       total: totalAdverts,
       page,
       limit,


### PR DESCRIPTION
## Contexto

Closes #80 

Las respuestas de anuncios no tenían un contrato consistente entre endpoints. Crear anuncio devolvía `id`, mientras que listar anuncios devolvía documentos de Mongo con `_id`. Además, `ownerId` podía venir como objeto poblado en el listado.

## Cambios

- Se añade un mapper para normalizar la respuesta de anuncios
- Crear anuncio usa el mapper para devolver el anuncio creado
- Listar anuncios devuelve `content` con anuncios normalizados
- Se expone `id` como identificador principal para frontend
- Se mantiene `ownerId` como id del propietario
- Se añade `owner` cuando el usuario viene populado

## Pruebas

- [x] `npm run build`