### PR TITLE
Feat/issue55 be contacto por formularioemail

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,13 +1,11 @@
 PORT=3000
-
-MONGO_URI=mongodb+srv://uri
-
-JWT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxx
-
+MONGO_URI=mongodb://localhost:27017/wallaclone
+JWT_SECRET=change-this-secret
 CORS_ORIGIN=http://localhost:5173
+SEED_DEMO_PASSWORD=change-demo-password
 
 MAIL_HOST=
 MAIL_PORT=
 MAIL_USER=
 MAIL_PASSWORD=
-MAIL_FROM=
+MAIL_FROM=no-reply@wallaclone.local

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,6 +2,7 @@ PORT=3000
 MONGO_URI=mongodb://localhost:27017/wallaclone
 JWT_SECRET=change-this-secret
 CORS_ORIGIN=http://localhost:5173
+FRONTEND_URL=http://localhost:5173
 SEED_DEMO_PASSWORD=change-demo-password
 
 MAIL_HOST=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,3 +5,9 @@ MONGO_URI=mongodb+srv://uri
 JWT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxx
 
 CORS_ORIGIN=http://localhost:5173
+
+MAIL_HOST=
+MAIL_PORT=
+MAIL_USER=
+MAIL_PASSWORD=
+MAIL_FROM=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,8 +5,8 @@ CORS_ORIGIN=http://localhost:5173
 FRONTEND_URL=http://localhost:5173
 SEED_DEMO_PASSWORD=change-demo-password
 
-MAIL_HOST=
+MAIL_HOST=smtp-relay.brevo.com
 MAIL_PORT=
 MAIL_USER=
 MAIL_PASSWORD=
-MAIL_FROM=no-reply@wallaclone.local
+MAIL_FROM=wallaclone.demo@gmail.com

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "http-status": "^2.1.0",
         "jsonwebtoken": "^9.0.3",
         "mongoose": "^9.4.1",
+        "nodemailer": "^7.0.13",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -23,6 +24,7 @@
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/node": "^25.6.0",
+        "@types/nodemailer": "^6.4.23",
         "@typescript-eslint/eslint-plugin": "^8.58.2",
         "@typescript-eslint/parser": "^8.58.2",
         "esbuild": "^0.28.0",
@@ -893,6 +895,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.23",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.23.tgz",
+      "integrity": "sha512-aFV3/NsYFLSx9mbb5gtirBSXJnAlrusoKNuPbxsASWc7vrKLmIrTQRpdcxNcSFL3VW2A2XpeLEavwb2qMi6nlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -4439,6 +4451,15 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
+      "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "http-status": "^2.1.0",
     "jsonwebtoken": "^9.0.3",
     "mongoose": "^9.4.1",
+    "nodemailer": "^7.0.13",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -28,6 +29,7 @@
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/node": "^25.6.0",
+    "@types/nodemailer": "^6.4.23",
     "@typescript-eslint/eslint-plugin": "^8.58.2",
     "@typescript-eslint/parser": "^8.58.2",
     "esbuild": "^0.28.0",

--- a/backend/src/controllers/products/AdvertInputValidator.ts
+++ b/backend/src/controllers/products/AdvertInputValidator.ts
@@ -53,8 +53,5 @@ export const mongoIdValidator = z.object({
 });
 
 export const contactMessageValidator = z.object({
-  contactMessage: trimmedString
-    .min(10, 'El mensaje no puede estar vacío')
-    .max(500, 'El mensaje es demasiado largo')
-    .default('Hola, me interesa el artículo publicado en vuestro anuncio'),
+  message: trimmedString.min(10).max(500),
 });

--- a/backend/src/controllers/products/AdvertInputValidator.ts
+++ b/backend/src/controllers/products/AdvertInputValidator.ts
@@ -16,17 +16,11 @@ const paginationValidator = {
   limit: z.coerce.number().int().positive().max(100).default(10),
 };
 
-const hasValidPriceRange = ({
-  minPrice,
-  maxPrice,
-}: {
-  minPrice?: number;
-  maxPrice?: number;
-}) => {
+const hasValidPriceRange = ({ minPrice, maxPrice }: { minPrice?: number; maxPrice?: number }) => {
   return minPrice === undefined || maxPrice === undefined || minPrice <= maxPrice;
 };
 
-const mongoIdSchema = z.string().refine((value) => Types.ObjectId.isValid(value), {
+const mongoIdSchema = z.string().refine(value => Types.ObjectId.isValid(value), {
   error: 'El ID proporcionado no tiene un formato válido',
 });
 
@@ -56,4 +50,11 @@ export const getAdvertsQueryValidator = z
 
 export const mongoIdValidator = z.object({
   id: mongoIdSchema,
+});
+
+export const contactMessageValidator = z.object({
+  contactMessage: trimmedString
+    .min(10, 'El mensaje no puede estar vacío')
+    .max(500, 'El mensaje es demasiado largo')
+    .default('Hola, me interesa el artículo publicado en vuestro anuncio'),
 });

--- a/backend/src/controllers/products/contactSellerController.ts
+++ b/backend/src/controllers/products/contactSellerController.ts
@@ -10,10 +10,10 @@ export const contactSellerController = async (req: Request, res: Response, next:
     }
 
     const { id } = mongoIdValidator.parse(req.params);
-    const { contactMessage: message } = contactMessageValidator.parse(req.body);
+    const { message } = contactMessageValidator.parse(req.body);
     const buyerId = req.user.id;
 
-    contactSeller(id, buyerId, message);
+    await contactSeller(id, buyerId, message);
 
     res.status(200).json({
       message: 'El mensaje ha sido enviado con éxito',

--- a/backend/src/controllers/products/contactSellerController.ts
+++ b/backend/src/controllers/products/contactSellerController.ts
@@ -1,0 +1,24 @@
+import { NextFunction, Request, Response } from 'express';
+import { UnauthorizedError } from '../../errors/domainError';
+import { contactMessageValidator, mongoIdValidator } from './AdvertInputValidator';
+import { contactSeller } from '../../services/contactSellerService';
+
+export const contactSellerController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    if (!req.user) {
+      throw new UnauthorizedError('Usuario no autenticado');
+    }
+
+    const { id } = mongoIdValidator.parse(req.params);
+    const { contactMessage: message } = contactMessageValidator.parse(req.body);
+    const buyerId = req.user.id;
+
+    contactSeller(id, buyerId, message);
+
+    res.status(200).json({
+      message: 'El mensaje ha sido enviado con éxito',
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/routes/webRoutes.ts
+++ b/backend/src/routes/webRoutes.ts
@@ -10,3 +10,4 @@ export const webRouter = express.Router();
 webRouter.post('/', authMiddleware, createAdvertController);
 webRouter.get('/', getAdsController);
 webRouter.delete('/:id', authMiddleware, deleteAdvertController);
+webRouter.post('/:id/contact', authMiddleware, deleteAdvertController);

--- a/backend/src/routes/webRoutes.ts
+++ b/backend/src/routes/webRoutes.ts
@@ -3,6 +3,7 @@ import { createAdvertController } from '../controllers/products/createAdvertCont
 import { getAdsController } from '../controllers/products/getAdsController';
 import { authMiddleware } from '../middlewares/authMiddleware';
 import { deleteAdvertController } from '../controllers/products/deleteAdController';
+import { contactSellerController } from '../controllers/products/contactSellerController';
 
 export const webRouter = express.Router();
 
@@ -10,4 +11,4 @@ export const webRouter = express.Router();
 webRouter.post('/', authMiddleware, createAdvertController);
 webRouter.get('/', getAdsController);
 webRouter.delete('/:id', authMiddleware, deleteAdvertController);
-webRouter.post('/:id/contact', authMiddleware, deleteAdvertController);
+webRouter.post('/:id/contact', authMiddleware,contactSellerController );

--- a/backend/src/services/contactSellerService.ts
+++ b/backend/src/services/contactSellerService.ts
@@ -34,7 +34,13 @@ export const contactSeller = async (advertId: string, buyerId: string, message: 
     throw new EntityNotFoundError('usuario', buyerId);
   }
 
-  const advertLink = `${process.env.CORS_ORIGIN}/adverts/${advertId}`;
+  const frontendUrl = (
+    process.env.FRONTEND_URL ??
+    process.env.CORS_ORIGIN ??
+    'http://localhost:5173'
+  ).replace(/\/$/, '');
+
+  const advertLink = `${frontendUrl}/adverts/${advertId}`;
 
   await emailService.sendContactEmail({
     sellerEmail: advert.ownerId.email,

--- a/backend/src/services/contactSellerService.ts
+++ b/backend/src/services/contactSellerService.ts
@@ -1,0 +1,41 @@
+import { Types } from 'mongoose';
+import { EntityNotFoundError, ForbiddenOperationError } from '../errors/domainError';
+import { Advert } from '../models/Advert';
+import { User } from '../models/User';
+import { emailService } from './emailService';
+
+interface PopulatedOwner {
+  _id: Types.ObjectId;
+  email: string;
+}
+
+export const contactSeller = async (advertId: string, buyerId: string, message: string) => {
+  const forSaleAdvert = await Advert.findById(advertId)
+    .populate<{ ownerId: PopulatedOwner }>('ownerId', 'email')
+    .lean();
+  if (!forSaleAdvert) {
+    throw new EntityNotFoundError('anuncio', advertId);
+  }
+  const sellerEmail = forSaleAdvert.ownerId.email;
+  const advertName = forSaleAdvert.name;
+
+  const advertOwnerId = forSaleAdvert.ownerId._id.toString();
+  if (advertOwnerId === buyerId) {
+    throw new ForbiddenOperationError('No puedes contactar con tu propio anuncio');
+  }
+
+  const buyer = await User.findById(buyerId).select('email username -_id').lean();
+  if (!buyer) {
+    throw new EntityNotFoundError('usuario', buyerId);
+  }
+  const { email: buyerEmail, username: buyerUsername } = buyer;
+
+  await emailService.sendContactEmail({
+    sellerEmail,
+    buyerEmail,
+    buyerUsername,
+    advertName,
+    message,
+  });
+  return
+};

--- a/backend/src/services/contactSellerService.ts
+++ b/backend/src/services/contactSellerService.ts
@@ -13,35 +13,35 @@ export const contactSeller = async (advertId: string, buyerId: string, message: 
   const advert = await Advert.findById(advertId)
     .populate<{ ownerId: PopulatedOwner }>('ownerId', 'email')
     .lean();
+
   if (!advert || advert.status === 'SOLD') {
     throw new EntityNotFoundError('anuncio', advertId);
   }
+
   if (!advert.ownerId) {
     throw new EntityNotFoundError('vendedor', 'id_no_disponible');
   }
-  const sellerEmail = advert.ownerId.email;
-  const advertName = advert.name;
 
   const advertOwnerId = advert.ownerId._id.toString();
+
   if (advertOwnerId === buyerId) {
     throw new ForbiddenOperationError('No puedes contactar con tu propio anuncio');
   }
 
   const buyer = await User.findById(buyerId).select('email username -_id').lean();
+
   if (!buyer) {
     throw new EntityNotFoundError('usuario', buyerId);
   }
-  const { email: buyerEmail, username: buyerUsername } = buyer;
 
   const advertLink = `${process.env.CORS_ORIGIN}/adverts/${advertId}`;
 
   await emailService.sendContactEmail({
-    sellerEmail,
-    buyerEmail,
-    buyerUsername,
-    advertName,
+    sellerEmail: advert.ownerId.email,
+    buyerEmail: buyer.email,
+    buyerUsername: buyer.username,
+    advertName: advert.name,
     message,
-    advertLink
+    advertLink,
   });
-  return;
 };

--- a/backend/src/services/contactSellerService.ts
+++ b/backend/src/services/contactSellerService.ts
@@ -10,16 +10,19 @@ interface PopulatedOwner {
 }
 
 export const contactSeller = async (advertId: string, buyerId: string, message: string) => {
-  const forSaleAdvert = await Advert.findById(advertId)
+  const advert = await Advert.findById(advertId)
     .populate<{ ownerId: PopulatedOwner }>('ownerId', 'email')
     .lean();
-  if (!forSaleAdvert) {
+  if (!advert) {
     throw new EntityNotFoundError('anuncio', advertId);
   }
-  const sellerEmail = forSaleAdvert.ownerId.email;
-  const advertName = forSaleAdvert.name;
+  if (!advert.ownerId) {
+    throw new EntityNotFoundError('vendedor', 'id_no_disponible');
+  }
+  const sellerEmail = advert.ownerId.email;
+  const advertName = advert.name;
 
-  const advertOwnerId = forSaleAdvert.ownerId._id.toString();
+  const advertOwnerId = advert.ownerId._id.toString();
   if (advertOwnerId === buyerId) {
     throw new ForbiddenOperationError('No puedes contactar con tu propio anuncio');
   }
@@ -37,5 +40,5 @@ export const contactSeller = async (advertId: string, buyerId: string, message: 
     advertName,
     message,
   });
-  return
+  return;
 };

--- a/backend/src/services/contactSellerService.ts
+++ b/backend/src/services/contactSellerService.ts
@@ -13,7 +13,7 @@ export const contactSeller = async (advertId: string, buyerId: string, message: 
   const advert = await Advert.findById(advertId)
     .populate<{ ownerId: PopulatedOwner }>('ownerId', 'email')
     .lean();
-  if (!advert) {
+  if (!advert || advert.status === 'SOLD') {
     throw new EntityNotFoundError('anuncio', advertId);
   }
   if (!advert.ownerId) {

--- a/backend/src/services/contactSellerService.ts
+++ b/backend/src/services/contactSellerService.ts
@@ -33,12 +33,15 @@ export const contactSeller = async (advertId: string, buyerId: string, message: 
   }
   const { email: buyerEmail, username: buyerUsername } = buyer;
 
+  const advertLink = `${process.env.CORS_ORIGIN}/adverts/${advertId}`;
+
   await emailService.sendContactEmail({
     sellerEmail,
     buyerEmail,
     buyerUsername,
     advertName,
     message,
+    advertLink
   });
   return;
 };

--- a/backend/src/services/emailService.ts
+++ b/backend/src/services/emailService.ts
@@ -5,7 +5,7 @@ class EmailService {
   private MAILTRAP_USERNAME = process.env.MAIL_USER;
   private MAILTRAP_PASSWORD = process.env.MAIL_PASSWORD;
   private MAILTRAP_HOST = process.env.MAIL_HOST;
-  private MAILTRAP_PORT = process.env.MAILTRAP_PORT;
+  private MAILTRAP_PORT = process.env.MAIL_PORT;
   private MAILTRAP_FROM = process.env.MAIL_FROM;
 
   constructor() {

--- a/backend/src/services/emailService.ts
+++ b/backend/src/services/emailService.ts
@@ -33,7 +33,7 @@ class EmailService {
     advertLink,
   }: SendContactEmailParams): Promise<void> {
     await this.transporter.sendMail({
-      from: `"${buyerUsername} a través de Wallaclone-GitGirls" <${this.mailFrom}>`,
+      from: `"Wallaclone GitGirls" <${this.mailFrom}>`,
       to: sellerEmail,
       subject: `Alguien se ha interesado en tu anuncio: ${advertName}`,
       text: `
@@ -48,7 +48,7 @@ class EmailService {
       Ver anuncio:
       ${advertLink}
 
-      Para contactar con el comprador responde directamente a este correo.
+      Para contactar con la persona interesada responde directamente a este correo.
       `,
       replyTo: buyerEmail,
     });

--- a/backend/src/services/emailService.ts
+++ b/backend/src/services/emailService.ts
@@ -35,7 +35,7 @@ class EmailService {
     await this.transporter.sendMail({
       from: `"${buyerUsername} a través de Wallaclone-GitGirls" <${this.MAILTRAP_FROM}>`,
       to: sellerEmail,
-      subject: `Nuevo mensaje sobre ${advertName}`,
+      subject: `Alguien se ha interesado en tu anuncio: ${advertName}`,
       text: message,
       html: `
       <h3>Has recibido un nuevo mensaje</h3> 

--- a/backend/src/services/emailService.ts
+++ b/backend/src/services/emailService.ts
@@ -1,0 +1,47 @@
+import nodemailer from 'nodemailer';
+
+class EmailService {
+  private transporter;
+  private MAILTRAP_USERNAME = process.env.MAIL_USER;
+  private MAILTRAP_PASSWORD = process.env.MAIL_PASSWORD;
+  private MAILTRAP_HOST = process.env.MAIL_HOST;
+  private MAILTRAP_PORT = process.env.MAILTRAP_PORT;
+  private MAILTRAP_FROM = process.env.MAIL_FROM;
+
+  constructor() {
+    this.transporter = nodemailer.createTransport({
+      host: this.MAILTRAP_HOST,
+      port: Number(this.MAILTRAP_PORT),
+      auth: {
+        user: this.MAILTRAP_USERNAME,
+        pass: this.MAILTRAP_PASSWORD,
+      },
+    });
+  }
+
+  async sendContactEmail({
+    sellerEmail,
+    buyerEmail,
+    buyerUsername,
+    advertName,
+    message,
+  }: {
+    sellerEmail: string;
+    buyerEmail: string;
+    buyerUsername: string;
+    advertName: string;
+    message: string;
+  }): Promise<void> {
+    await this.transporter.sendMail({
+      from: `"${buyerUsername} a través de Wallaclone-GitGirls" <${this.MAILTRAP_FROM}>`,
+      to: sellerEmail,
+      subject: `Nuevo mensaje sobre ${advertName}`,
+      text: `Has recibido un nuevo mensaje del usuario ${buyerUsername} por tu anuncio ${advertName}.
+      mensaje: ${message} 
+      Puedes responder directamente a este email para contactar con el comprador.`,
+      replyTo: buyerEmail,
+    });
+  }
+}
+
+export const emailService = new EmailService();

--- a/backend/src/services/emailService.ts
+++ b/backend/src/services/emailService.ts
@@ -25,12 +25,14 @@ class EmailService {
     buyerUsername,
     advertName,
     message,
+    advertLink
   }: {
     sellerEmail: string;
     buyerEmail: string;
     buyerUsername: string;
     advertName: string;
     message: string;
+    advertLink:string
   }): Promise<void> {
     await this.transporter.sendMail({
       from: `"${buyerUsername} a través de Wallaclone-GitGirls" <${this.MAILTRAP_FROM}>`,
@@ -43,6 +45,7 @@ class EmailService {
       <p><strong>Anuncio:</strong> ${advertName}</p>
       <p><strong>Mensaje:</strong></p>
       <p>${message}</p>
+      <p><strong>Ver anuncio:</strong>${advertLink}</p>
       <h4><i>Para contactar con el comprador responde directamente a este correo.</h4></i>`,
       replyTo: buyerEmail,
     });

--- a/backend/src/services/emailService.ts
+++ b/backend/src/services/emailService.ts
@@ -36,9 +36,14 @@ class EmailService {
       from: `"${buyerUsername} a través de Wallaclone-GitGirls" <${this.MAILTRAP_FROM}>`,
       to: sellerEmail,
       subject: `Nuevo mensaje sobre ${advertName}`,
-      text: `Has recibido un nuevo mensaje del usuario ${buyerUsername} por tu anuncio ${advertName}.
-      mensaje: ${message} 
-      Puedes responder directamente a este email para contactar con el comprador.`,
+      text: message,
+      html: `
+      <h3>Has recibido un nuevo mensaje</h3> 
+      <p><strong>Usuario:</strong> ${buyerUsername}</p>
+      <p><strong>Anuncio:</strong> ${advertName}</p>
+      <p><strong>Mensaje:</strong></p>
+      <p>${message}</p>
+      <h4><i>Para contactar con el comprador responde directamente a este correo.</h4></i>`,
       replyTo: buyerEmail,
     });
   }

--- a/backend/src/services/emailService.ts
+++ b/backend/src/services/emailService.ts
@@ -1,20 +1,25 @@
-import nodemailer from 'nodemailer';
+import nodemailer, { type Transporter } from 'nodemailer';
+
+type SendContactEmailParams = {
+  sellerEmail: string;
+  buyerEmail: string;
+  buyerUsername: string;
+  advertName: string;
+  message: string;
+  advertLink: string;
+};
 
 class EmailService {
-  private transporter;
-  private mailHost = process.env.MAIL_HOST;
-  private mailPort = process.env.MAIL_PORT;
-  private mailUser = process.env.MAIL_USER;
-  private mailPassword = process.env.MAIL_PASSWORD;
-  private mailFrom = process.env.MAIL_FROM;
+  private transporter: Transporter;
+  private mailFrom = process.env.MAIL_FROM ?? 'no-reply@wallaclone.local';
 
   constructor() {
     this.transporter = nodemailer.createTransport({
-      host: this.MAILTRAP_HOST,
-      port: Number(this.MAILTRAP_PORT),
+      host: process.env.MAIL_HOST,
+      port: Number(process.env.MAIL_PORT ?? 587),
       auth: {
-        user: this.MAILTRAP_USERNAME,
-        pass: this.MAILTRAP_PASSWORD,
+        user: process.env.MAIL_USER,
+        pass: process.env.MAIL_PASSWORD,
       },
     });
   }
@@ -25,28 +30,22 @@ class EmailService {
     buyerUsername,
     advertName,
     message,
-    advertLink
-  }: {
-    sellerEmail: string;
-    buyerEmail: string;
-    buyerUsername: string;
-    advertName: string;
-    message: string;
-    advertLink:string
-  }): Promise<void> {
+    advertLink,
+  }: SendContactEmailParams): Promise<void> {
     await this.transporter.sendMail({
-      from: `"${buyerUsername} a través de Wallaclone-GitGirls" <${this.MAILTRAP_FROM}>`,
+      from: `"${buyerUsername} a través de Wallaclone-GitGirls" <${this.mailFrom}>`,
       to: sellerEmail,
       subject: `Alguien se ha interesado en tu anuncio: ${advertName}`,
       text: message,
       html: `
-      <h3>Has recibido un nuevo mensaje</h3> 
-      <p><strong>Usuario:</strong> ${buyerUsername}</p>
-      <p><strong>Anuncio:</strong> ${advertName}</p>
-      <p><strong>Mensaje:</strong></p>
-      <p>${message}</p>
-      <p><strong>Ver anuncio:</strong>${advertLink}</p>
-      <h4><i>Para contactar con el comprador responde directamente a este correo.</h4></i>`,
+        <h3>Has recibido un nuevo mensaje</h3>
+        <p><strong>Usuario:</strong> ${buyerUsername}</p>
+        <p><strong>Anuncio:</strong> ${advertName}</p>
+        <p><strong>Mensaje:</strong></p>
+        <p>${message}</p>
+        <p><strong>Ver anuncio:</strong> ${advertLink}</p>
+        <h4><i>Para contactar con el comprador responde directamente a este correo.</i></h4>
+      `,
       replyTo: buyerEmail,
     });
   }

--- a/backend/src/services/emailService.ts
+++ b/backend/src/services/emailService.ts
@@ -2,11 +2,11 @@ import nodemailer from 'nodemailer';
 
 class EmailService {
   private transporter;
-  private MAILTRAP_USERNAME = process.env.MAIL_USER;
-  private MAILTRAP_PASSWORD = process.env.MAIL_PASSWORD;
-  private MAILTRAP_HOST = process.env.MAIL_HOST;
-  private MAILTRAP_PORT = process.env.MAIL_PORT;
-  private MAILTRAP_FROM = process.env.MAIL_FROM;
+  private mailHost = process.env.MAIL_HOST;
+  private mailPort = process.env.MAIL_PORT;
+  private mailUser = process.env.MAIL_USER;
+  private mailPassword = process.env.MAIL_PASSWORD;
+  private mailFrom = process.env.MAIL_FROM;
 
   constructor() {
     this.transporter = nodemailer.createTransport({

--- a/backend/src/services/emailService.ts
+++ b/backend/src/services/emailService.ts
@@ -36,15 +36,19 @@ class EmailService {
       from: `"${buyerUsername} a través de Wallaclone-GitGirls" <${this.mailFrom}>`,
       to: sellerEmail,
       subject: `Alguien se ha interesado en tu anuncio: ${advertName}`,
-      text: message,
-      html: `
-        <h3>Has recibido un nuevo mensaje</h3>
-        <p><strong>Usuario:</strong> ${buyerUsername}</p>
-        <p><strong>Anuncio:</strong> ${advertName}</p>
-        <p><strong>Mensaje:</strong></p>
-        <p>${message}</p>
-        <p><strong>Ver anuncio:</strong> ${advertLink}</p>
-        <h4><i>Para contactar con el comprador responde directamente a este correo.</i></h4>
+      text: `
+      Has recibido un nuevo mensaje en Wallaclone.
+
+      Usuario: ${buyerUsername}
+      Anuncio: ${advertName}
+
+      Mensaje:
+      ${message}
+
+      Ver anuncio:
+      ${advertLink}
+
+      Para contactar con el comprador responde directamente a este correo.
       `,
       replyTo: buyerEmail,
     });


### PR DESCRIPTION
### 🚀 PR: Contacto con vendedor por formulario/email

## 📝 Descripción

Se implementa la funcionalidad backend para que un usuario autenticado pueda contactar con el vendedor de un anuncio mediante un formulario.

Esta funcionalidad funciona como alternativa MVP al chat completo: el usuario interesado escribe un mensaje desde Wallaclone y el backend envía un email al propietario del anuncio. No se expone el email del vendedor en frontend.

El vendedor recibe el mensaje por correo y puede responder directamente a la persona interesada gracias al campo `replyTo`.

---

## 🛠️ Especificación técnica

### Ruta Express
`POST /adverts/:id/contact`

### Ruta prevista en producción
`POST /api/adverts/:id/contact`


> Nota: Express no define el prefijo `/api`. En producción, si la API se expone bajo `/api`, ese prefijo lo gestiona Nginx.

### Seguridad

La ruta requiere JWT válido mediante `authMiddleware`.

El frontend debe enviar:
`Authorization: Bearer <token>`

### Body esperado
````html
{
  "message": "Hola, me interesa este anuncio. ¿Sigue disponible?"
}
````

### Respuesta correcta
````html
{
  "message": "El mensaje ha sido enviado con éxito"
}
````


---

## ✅ Checklist de implementación

- [x] Añadido endpoint `POST /adverts/:id/contact`
- [x] Protegida la ruta con `authMiddleware`
- [x] Validado el `id` del anuncio como ObjectId válido de MongoDB
- [x] Validado el mensaje con Zod
- [x] Comprobado que el anuncio existe
- [x] Comprobado que el anuncio no está vendido
- [x] Comprobado que el usuario autenticado no contacta con su propio anuncio
- [x] Obtenido el email del vendedor mediante `populate`
- [x] Obtenidos los datos del comprador desde base de datos
- [x] Añadido servicio `contactSellerService`
- [x] Añadido servicio `emailService` desacoplado con Nodemailer
- [x] Configurado `replyTo` con el email de la persona interesada
- [x] Añadidas variables de entorno de correo en `.env.example`
- [x] Añadida variable `FRONTEND_URL` para construir enlaces al anuncio en emails
- [x] Añadida dependencia `nodemailer`
- [x] Añadidos tipos `@types/nodemailer`

---

## 📩 Configuración de email

El servicio de email usa Nodemailer con variables SMTP genéricas.

Variables necesarias:
````text
MAIL_HOST=
MAIL_PORT=
MAIL_USER=
MAIL_PASSWORD=
MAIL_FROM=
````


Esto permite usar distintos proveedores SMTP sin cambiar la lógica del código.

Para desarrollo puede probarse con Mailtrap, Brevo u otro proveedor SMTP.

Para producción se prevé usar Brevo configurando estas variables en el `.env` real del servidor.

Ejemplo de configuración para producción:
````
MAIL_HOST=smtp-relay.brevo.com
MAIL_PORT=587
MAIL_USER=usuario_smtp
MAIL_PASSWORD=clave_smtp
MAIL_FROM=wallaclone.demo@gmail.com
````

---

## 🌐 FRONTEND_URL

Se añade `FRONTEND_URL` para construir el enlace al anuncio dentro del email.

Local:
`FRONTEND_URL=http://localhost:5173/`

Producción:
`FRONTEND_URL=https://wallaclone.gitgirlskcweb19.duckdns.org/`

## 🧪 Testing / comprobaciones

Comprobado:

- [x] `npm run build`
- [x] Backend build correcto
- [x] Backend ESLint correcto
- [x] Frontend build correcto
- [x] Frontend ESLint correcto
- [x] PR sin conflictos con `main`

---

## 🔗 Issues relacionadas

Closes #55
