### PR TITLE
[FE] Crear un anuncio

### DIFF
--- a/frontend/wallaclone/src/App.tsx
+++ b/frontend/wallaclone/src/App.tsx
@@ -3,6 +3,7 @@ import Layout from './components/layout/Layout'
 import HomePage from './pages/HomePage'
 import RegisterPage from './pages/RegisterPage'
 import LoginPage from './pages/LoginPage'
+import CreateAdvertPage from './pages/CreateAdvertPage'
 
 function App() {
   return (
@@ -12,6 +13,7 @@ function App() {
         <Route path="/register" element={<RegisterPage />} />
         <Route element={<Layout />}>
           <Route path="/" element={<HomePage />} />
+          <Route path="/adverts/new" element={<CreateAdvertPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/frontend/wallaclone/src/components/layout/Header.tsx
+++ b/frontend/wallaclone/src/components/layout/Header.tsx
@@ -1,9 +1,34 @@
 import { Link } from 'react-router-dom'
 
 function Header() {
+    const token = localStorage.getItem("token");
+
     return (
         <header className="bg-white shadow p-4">
-            <Link to="/" className="text-xl font-bold">Wallaclone</Link>
+            <div className="mx-auto flex max-w-7xl items-center justify-between">
+                <Link to="/" className="text-xl font-bold text-[#00bba7]">
+                    Wallaclone
+                </Link>
+
+                <nav className="flex items-center gap-4 text-sm font-medium">
+                    <Link to="/" className="text-gray-700 hover:text-[#00bba7]">
+                        Anuncios
+                    </Link>
+
+                    {token ? (
+                        <Link
+                            to="/adverts/new"
+                            className="rounded-md bg-[#00bba7] px-4 py-2 text-white hover:bg-[#009689]"
+                        >
+                            Crear anuncio
+                        </Link>
+                    ) : (
+                        <Link to="/login" className="text-gray-700 hover:text-[#00bba7]">
+                            Iniciar sesión
+                        </Link>
+                    )}
+                </nav>
+            </div>
         </header>
     )
 }

--- a/frontend/wallaclone/src/pages/CreateAdvertPage.tsx
+++ b/frontend/wallaclone/src/pages/CreateAdvertPage.tsx
@@ -1,0 +1,315 @@
+import { useEffect, useState, type SyntheticEvent } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { createAdvert } from "../services/advertService";
+
+type CreateAdvertErrors = {
+    name?: string;
+    description?: string;
+    price?: string;
+    image?: string;
+    tags?: string;
+    general?: string;
+};
+
+function CreateAdvertPage() {
+    const navigate = useNavigate();
+
+    const [name, setName] = useState("");
+    const [description, setDescription] = useState("");
+    const [price, setPrice] = useState("");
+    const [image, setImage] = useState("");
+    const [tags, setTags] = useState("");
+    const [isLoading, setIsLoading] = useState(false);
+    const [errors, setErrors] = useState<CreateAdvertErrors>({});
+
+    useEffect(() => {
+        const token = localStorage.getItem("token");
+
+        if (!token) {
+            navigate("/login");
+        }
+    }, [navigate]);
+
+    const getParsedTags = () => {
+        return tags
+            .split(",")
+            .map((tag) => tag.trim().toLowerCase())
+            .filter(Boolean);
+    };
+
+    const validate = () => {
+        const newErrors: CreateAdvertErrors = {};
+        const numericPrice = Number(price);
+
+        if (!name.trim()) {
+            newErrors.name = "El nombre es obligatorio";
+        } else if (name.trim().length < 2) {
+            newErrors.name = "El nombre debe tener al menos 2 caracteres";
+        }
+
+        if (!description.trim()) {
+            newErrors.description = "La descripción es obligatoria";
+        } else if (description.trim().length < 5) {
+            newErrors.description = "La descripción debe tener al menos 5 caracteres";
+        } else if (description.trim().length > 200) {
+            newErrors.description = "La descripción no puede tener más de 200 caracteres";
+        }
+
+        if (!price.trim()) {
+            newErrors.price = "El precio es obligatorio";
+        } else if (Number.isNaN(numericPrice) || numericPrice <= 0) {
+            newErrors.price = "El precio tiene que ser mayor a cero";
+        }
+
+        if (!image.trim()) {
+            newErrors.image = "La imagen es obligatoria";
+        } else {
+            try {
+                new URL(image.trim());
+            } catch {
+                newErrors.image = "La imagen debe ser una URL válida";
+            }
+        }
+
+        if (getParsedTags().length === 0) {
+            newErrors.tags = "Añade al menos un tag";
+        }
+
+        setErrors(newErrors);
+        return Object.keys(newErrors).length === 0;
+    };
+
+    const handleSubmit = async (event: SyntheticEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        if (!validate()) {
+            return;
+        }
+
+        try {
+            setIsLoading(true);
+            setErrors({});
+
+            await createAdvert({
+                name: name.trim(),
+                description: description.trim(),
+                price: Number(price),
+                isSale: true,
+                image: image.trim(),
+                tags: getParsedTags(),
+            });
+
+            navigate("/");
+        } catch (error) {
+            setErrors({
+                general:
+                    error instanceof Error
+                        ? error.message
+                        : "No se ha podido crear el anuncio",
+            });
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <section className="min-h-full bg-gray-50 px-6 py-8">
+            <div className="mx-auto max-w-3xl">
+                <div className="mb-8">
+                    <Link
+                        to="/"
+                        className="text-sm font-medium text-[#00bba7] hover:underline"
+                    >
+                        Volver a los anuncios
+                    </Link>
+
+                    <h1 className="mt-4 text-3xl font-bold tracking-tight text-gray-900">
+                        Crear un anuncio
+                    </h1>
+
+                    <p className="mt-2 text-base text-gray-600">
+                        Publica un artículo para vender
+                    </p>
+                </div>
+
+                <form
+                    onSubmit={handleSubmit}
+                    className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm"
+                    noValidate
+                >
+                    {errors.general && (
+                        <p className="mb-4 rounded-lg bg-red-50 px-4 py-3 text-sm text-red-700">
+                            {errors.general}
+                        </p>
+                    )}
+
+                    <div className="mb-5">
+                        <label
+                            htmlFor="name"
+                            className="mb-1 block text-sm font-medium text-gray-700"
+                        >
+                            Nombre del artículo
+                        </label>
+                        <input
+                            id="name"
+                            type="text"
+                            value={name}
+                            onChange={(event) => {
+                                setName(event.target.value);
+                                setErrors((prevErrors) => ({
+                                    ...prevErrors,
+                                    name: undefined,
+                                    general: undefined,
+                                }));
+                            }}
+                            className={`w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#00bba7] ${errors.name ? "border-red-500" : "border-gray-300"
+                                }`}
+                            placeholder="Ej. Bicicleta Orbea de montaña"
+                        />
+                        {errors.name && (
+                            <p className="mt-1 text-xs text-red-500">{errors.name}</p>
+                        )}
+                    </div>
+
+                    <div className="mb-5">
+                        <label
+                            htmlFor="description"
+                            className="mb-1 block text-sm font-medium text-gray-700"
+                        >
+                            Descripción
+                        </label>
+                        <textarea
+                            id="description"
+                            value={description}
+                            onChange={(event) => {
+                                setDescription(event.target.value);
+                                setErrors((prevErrors) => ({
+                                    ...prevErrors,
+                                    description: undefined,
+                                    general: undefined,
+                                }));
+                            }}
+                            rows={5}
+                            maxLength={200}
+                            className={`w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#00bba7] ${errors.description ? "border-red-500" : "border-gray-300"
+                                }`}
+                            placeholder="Describe el estado, detalles importantes y cualquier información útil."
+                        />
+                        <div className="mt-1 flex items-center justify-between">
+                            {errors.description ? (
+                                <p className="text-xs text-red-500">
+                                    {errors.description}
+                                </p>
+                            ) : (
+                                <span />
+                            )}
+                            <p className="text-xs text-gray-400">
+                                {description.length}/200
+                            </p>
+                        </div>
+                    </div>
+
+                    <div className="mb-5">
+                        <label
+                            htmlFor="price"
+                            className="mb-1 block text-sm font-medium text-gray-700"
+                        >
+                            Precio de venta
+                        </label>
+                        <input
+                            id="price"
+                            type="number"
+                            min="1"
+                            step="1"
+                            value={price}
+                            onChange={(event) => {
+                                setPrice(event.target.value);
+                                setErrors((prevErrors) => ({
+                                    ...prevErrors,
+                                    price: undefined,
+                                    general: undefined,
+                                }));
+                            }}
+                            className={`w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#00bba7] ${errors.price ? "border-red-500" : "border-gray-300"
+                                }`}
+                            placeholder="Ej. 120"
+                        />
+                        {errors.price && (
+                            <p className="mt-1 text-xs text-red-500">{errors.price}</p>
+                        )}
+                    </div>
+
+                    <div className="mb-5">
+                        <label
+                            htmlFor="image"
+                            className="mb-1 block text-sm font-medium text-gray-700"
+                        >
+                            URL de la imagen
+                        </label>
+                        <input
+                            id="image"
+                            type="url"
+                            value={image}
+                            onChange={(event) => {
+                                setImage(event.target.value);
+                                setErrors((prevErrors) => ({
+                                    ...prevErrors,
+                                    image: undefined,
+                                    general: undefined,
+                                }));
+                            }}
+                            className={`w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#00bba7] ${errors.image ? "border-red-500" : "border-gray-300"
+                                }`}
+                            placeholder="https://picsum.photos/seed/mi-anuncio/800/600"
+                        />
+                        {errors.image && (
+                            <p className="mt-1 text-xs text-red-500">{errors.image}</p>
+                        )}
+                    </div>
+
+                    <div className="mb-6">
+                        <label
+                            htmlFor="tags"
+                            className="mb-1 block text-sm font-medium text-gray-700"
+                        >
+                            Tags
+                        </label>
+                        <input
+                            id="tags"
+                            type="text"
+                            value={tags}
+                            onChange={(event) => {
+                                setTags(event.target.value);
+                                setErrors((prevErrors) => ({
+                                    ...prevErrors,
+                                    tags: undefined,
+                                    general: undefined,
+                                }));
+                            }}
+                            className={`w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#00bba7] ${errors.tags ? "border-red-500" : "border-gray-300"
+                                }`}
+                            placeholder="movil, samsung, android"
+                        />
+                        {errors.tags ? (
+                            <p className="mt-1 text-xs text-red-500">{errors.tags}</p>
+                        ) : (
+                            <p className="mt-1 text-xs text-gray-400">
+                                Separa los tags con comas
+                            </p>
+                        )}
+                    </div>
+
+                    <button
+                        type="submit"
+                        disabled={isLoading}
+                        className="w-full rounded-md bg-[#00bba7] py-2 text-sm font-semibold text-white transition-colors hover:bg-[#009689] disabled:cursor-not-allowed disabled:bg-gray-300"
+                    >
+                        {isLoading ? "Creando anuncio..." : "Crear anuncio"}
+                    </button>
+                </form>
+            </div>
+        </section>
+    );
+}
+
+export default CreateAdvertPage;

--- a/frontend/wallaclone/src/services/advertService.ts
+++ b/frontend/wallaclone/src/services/advertService.ts
@@ -23,6 +23,19 @@ type GetAdvertsResponse = {
     limit: number;
 };
 
+export type CreateAdvertData = {
+    name: string;
+    description: string;
+    price: number;
+    isSale: boolean;
+    image: string;
+    tags: string[];
+};
+
+type CreateAdvertResponse = Advert & {
+    message?: string;
+};
+
 export async function getLatestAdverts(): Promise<GetAdvertsResponse> {
     const response = await fetch(`${API_BASE_URL}/adverts?limit=12&page=1`);
 
@@ -31,6 +44,35 @@ export async function getLatestAdverts(): Promise<GetAdvertsResponse> {
     if (!response.ok) {
         throw new Error(
             data?.message ?? data?.error ?? "No se han podido cargar los anuncios",
+        );
+    }
+
+    return data;
+}
+
+export async function createAdvert(
+    advertData: CreateAdvertData,
+): Promise<CreateAdvertResponse> {
+    const token = localStorage.getItem("token");
+
+    if (!token) {
+        throw new Error("Tienes que iniciar sesión para crear un anuncio");
+    }
+
+    const response = await fetch(`${API_BASE_URL}/adverts`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(advertData),
+    });
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok) {
+        throw new Error(
+            data?.message ?? data?.error ?? "No se ha podido crear el anuncio",
         );
     }
 


### PR DESCRIPTION
## Contexto

Closes #40

---

## Cambios

- Añade la página para crear un anuncio desde el frontend
- Añade el servicio para enviar la creación del anuncio al backend
- Añade la ruta `/adverts/new`
- Añade enlace de navegación para acceder a crear anuncio
- Envía el anuncio como anuncio de venta (`isSale: true`) porque la búsqueda de artículos se hará desde el buscador

---

## Pruebas

- [x] `npm run build`
- [x] `npm run lint`
- [x] Login con usuario registrado
- [x] Crear anuncio autenticada
- [x] Ver que el anuncio se crea correctamente