### PR TITLE
[FE] Preparar borrado de anuncios

### DIFF
--- a/frontend/wallaclone/src/components/adverts/AdvertCard.tsx
+++ b/frontend/wallaclone/src/components/adverts/AdvertCard.tsx
@@ -2,6 +2,9 @@ import type { Advert } from "../../services/advertService";
 
 type AdvertCardProps = {
     advert: Advert;
+    canDelete?: boolean;
+    isDeleting?: boolean;
+    onDelete?: (advertId: string) => void;
 };
 
 function getAdvertTypeLabel(isSale: boolean) {
@@ -22,7 +25,12 @@ function getOwnerName(owner?: Advert["owner"]) {
     return owner?.username ?? "Usuario";
 }
 
-function AdvertCard({ advert }: AdvertCardProps) {
+function AdvertCard({
+    advert,
+    canDelete = false,
+    isDeleting = false,
+    onDelete,
+}: AdvertCardProps) {
     return (
         <article className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md">
             <div className="h-48 bg-gray-100">
@@ -85,6 +93,17 @@ function AdvertCard({ advert }: AdvertCardProps) {
                                 #{tag}
                             </span>
                         ))}
+                        
+                        {canDelete && (
+                            <button
+                                type="button"
+                                onClick={() => onDelete?.(advert.id)}
+                                disabled={isDeleting}
+                                className="w-full rounded-xl border border-red-200 px-4 py-2 text-sm font-semibold text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                                {isDeleting ? "Borrando..." : "Borrar anuncio"}
+                            </button>
+                        )}
                     </div>
                 )}
             </div>

--- a/frontend/wallaclone/src/pages/AdvertDetailPage.tsx
+++ b/frontend/wallaclone/src/pages/AdvertDetailPage.tsx
@@ -1,6 +1,16 @@
 import { useEffect, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { getAdvertById, type Advert } from "../services/advertService";
+import { deleteAdvert } from "../services/deleteAdvertService";
+
+type StoredUser = {
+    id?: string;
+    _id?: string;
+    user?: {
+        id?: string;
+        _id?: string;
+    };
+};
 
 function getAdvertStatusLabel(status: Advert["status"]) {
     const statusLabels = {
@@ -16,8 +26,37 @@ function getOwnerName(owner?: Advert["owner"]) {
     return owner?.username ?? "Usuario";
 }
 
+function getCurrentUserId() {
+    const storageKeys = ["user", "currentUser"];
+
+    for (const storageKey of storageKeys) {
+        const storedUser = localStorage.getItem(storageKey);
+
+        if (!storedUser) {
+            continue;
+        }
+
+        try {
+            const parsedUser = JSON.parse(storedUser) as StoredUser;
+
+            return (
+                parsedUser.id ??
+                parsedUser._id ??
+                parsedUser.user?.id ??
+                parsedUser.user?._id ??
+                null
+            );
+        } catch {
+            return null;
+        }
+    }
+
+    return null;
+}
+
 function AdvertDetailPage() {
     const { advertId } = useParams();
+    const navigate = useNavigate();
     const [advert, setAdvert] = useState<Advert | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [errorMessage, setErrorMessage] = useState("");
@@ -72,6 +111,36 @@ function AdvertDetailPage() {
                 </div>
             </section>
         );
+    }
+
+    const currentUserId = getCurrentUserId();
+    const canManageAdvert = Boolean(currentUserId && currentUserId === advert.ownerId);
+
+    async function handleDeleteAdvert() {
+        if (!advert) {
+            return;
+        }
+
+        const advertToDelete = advert;
+
+        const confirmed = window.confirm(
+            `¿Seguro que quieres eliminar el anuncio "${advertToDelete.name}"?`,
+        );
+
+        if (!confirmed) {
+            return;
+        }
+
+        try {
+            await deleteAdvert(advertToDelete.id);
+            navigate("/", { replace: true });
+        } catch (error) {
+            setErrorMessage(
+                error instanceof Error
+                    ? error.message
+                    : "No se ha podido eliminar el anuncio",
+            );
+        }
     }
 
     return (
@@ -158,6 +227,26 @@ function AdvertDetailPage() {
                                             </span>
                                         ))}
                                     </div>
+                                </div>
+                            )}
+
+                            {canManageAdvert && (
+                                <div className="flex flex-wrap gap-3 border-t border-gray-100 pt-6">
+                                    <Link
+                                        to={`/adverts/${advert.id}/edit`}
+                                        state={{ advert }}
+                                        className="rounded-md bg-[#00bba7] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#009689]"
+                                    >
+                                        Editar anuncio
+                                    </Link>
+
+                                    <button
+                                        type="button"
+                                        onClick={handleDeleteAdvert}
+                                        className="rounded-md border border-red-500 px-4 py-2 text-sm font-semibold text-red-600 transition-colors hover:bg-red-500 hover:text-white"
+                                    >
+                                        Eliminar anuncio
+                                    </button>
                                 </div>
                             )}
                         </div>

--- a/frontend/wallaclone/src/services/deleteAdvertService.ts
+++ b/frontend/wallaclone/src/services/deleteAdvertService.ts
@@ -1,0 +1,24 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:3000";
+
+export async function deleteAdvert(advertId: string): Promise<void> {
+    const token = localStorage.getItem("token");
+
+    if (!token) {
+        throw new Error("No se ha podido validar la sesión");
+    }
+
+    const response = await fetch(`${API_BASE_URL}/adverts/${advertId}`, {
+        method: "DELETE",
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    });
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok) {
+        throw new Error(
+            data?.message ?? data?.error ?? "No se ha podido borrar el anuncio",
+        );
+    }
+}


### PR DESCRIPTION
## Contexto

Closes #41

---

## Cambios

- Añade servicio frontend para borrar anuncios con `DELETE /adverts/:id`
- Prepara `AdvertCard` para poder mostrar acción de borrado cuando la página contenedora lo permita
- Mantiene la home como listado público, sin mostrar acciones de gestión de anuncios

---

## Pendiente
- Integrar el botón de borrar en la página de detalle del anuncio o en una futura página de "Mis anuncios"
- Comprobar que solo el propietario del anuncio ve la acción de borrado
- Confirmar borrado antes de llamar a la API

---

## Pruebas
- [x] `npm run lint`
- [x] `npm run build`