### PR TITLE
[BE] Editar un anuncio

### DIFF
--- a/backend/src/controllers/products/AdvertInputValidator.ts
+++ b/backend/src/controllers/products/AdvertInputValidator.ts
@@ -13,13 +13,7 @@ const paginationValidator = {
   limit: z.coerce.number().int().positive().max(100).default(10),
 };
 
-const hasValidPriceRange = ({
-  minPrice,
-  maxPrice,
-}: {
-  minPrice?: number;
-  maxPrice?: number;
-}) => {
+const hasValidPriceRange = ({ minPrice, maxPrice }: { minPrice?: number; maxPrice?: number }) => {
   return minPrice === undefined || maxPrice === undefined || minPrice <= maxPrice;
 };
 
@@ -46,3 +40,8 @@ export const getAdvertsQueryValidator = z
     error: 'El precio mínimo debe ser menor o igual que el precio máximo',
     path: ['minPrice'],
   });
+
+
+
+  
+export const updateAdValidator = createAdBodyValidator.partial();

--- a/backend/src/controllers/products/updateAdvertController.ts
+++ b/backend/src/controllers/products/updateAdvertController.ts
@@ -1,39 +1,38 @@
-import { NextFunction, Request, Response } from 'express';
+import type { RequestHandler } from 'express';
 import {
   EntityNotFoundError,
   ForbiddenOperationError,
   UnauthorizedError,
 } from '../../errors/domainError';
-import { mongoIdValidator, updateAdValidator } from './AdvertInputValidator';
 import { Advert } from '../../models/Advert';
+import { mongoIdValidator, updateAdValidator } from './AdvertInputValidator';
+import { mapAdvertToResponse } from './advertResponseMapper';
 
-export const updateAdvertController = async (req: Request, res: Response, next: NextFunction) => {
+export const updateAdvertController: RequestHandler = async (req, res, next) => {
   try {
     if (!req.user) {
       throw new UnauthorizedError('Usuario no autenticado');
     }
+
     const dataToUpdate = updateAdValidator.parse(req.body);
     const { id } = mongoIdValidator.parse(req.params);
 
     const advertToUpdate = await Advert.findById(id);
+
     if (!advertToUpdate) {
-      throw new EntityNotFoundError('anuncio', 'id');
+      throw new EntityNotFoundError('anuncio', id);
     }
+
     if (advertToUpdate.ownerId.toString() !== req.user.id) {
-      throw new ForbiddenOperationError('No tiene permisos para editar este anuncio');
+      throw new ForbiddenOperationError('No tienes permisos para editar este anuncio');
     }
+
     advertToUpdate.set(dataToUpdate);
+
     const updatedAdvert = await advertToUpdate.save();
 
     res.status(200).json({
-      id: updatedAdvert._id,
-      name: updatedAdvert.name,
-      description: updatedAdvert.description,
-      price: updatedAdvert.price,
-      isSale: updatedAdvert.isSale,
-      ownerId: updatedAdvert.ownerId,
-      image: updatedAdvert.image,
-      status: updatedAdvert.status,
+      ...mapAdvertToResponse(updatedAdvert),
       message: 'Anuncio actualizado con éxito',
     });
   } catch (error) {

--- a/backend/src/controllers/products/updateAdvertController.ts
+++ b/backend/src/controllers/products/updateAdvertController.ts
@@ -4,27 +4,16 @@ import {
   ForbiddenOperationError,
   UnauthorizedError,
 } from '../../errors/domainError';
-import { updateAdValidator } from './AdvertInputValidator';
+import { mongoIdValidator, updateAdValidator } from './AdvertInputValidator';
 import { Advert } from '../../models/Advert';
-import { User } from '../../models/User';
 
 export const updateAdvertController = async (req: Request, res: Response, next: NextFunction) => {
   try {
     if (!req.user) {
       throw new UnauthorizedError('Usuario no autenticado');
     }
-    const { name, description, price, isSale, image, tags } = updateAdValidator.parse(req.body);
-    //TODO: aca va la validacion de la mongoId, pero como la tengo cojo la id sin validar
-    const advertInfoToUpdate = new Advert({
-      name,
-      description,
-      price,
-      isSale,
-      image,
-      tags,
-    });
-
-    const { id } = req.params;
+    const dataToUpdate = updateAdValidator.parse(req.body);
+    const { id } = mongoIdValidator.parse(req.params);
 
     const advertToUpdate = await Advert.findById(id);
     if (!advertToUpdate) {
@@ -33,8 +22,8 @@ export const updateAdvertController = async (req: Request, res: Response, next: 
     if (advertToUpdate.ownerId.toString() !== req.user.id) {
       throw new ForbiddenOperationError('No tiene permisos para editar este anuncio');
     }
-
-    const updatedAdvert = await Advert.updateOne(id, advertInfoToUpdate);
+    advertToUpdate.set(dataToUpdate);
+    const updatedAdvert = await advertToUpdate.save();
 
     res.status(200).json({
       id: updatedAdvert._id,
@@ -43,7 +32,7 @@ export const updateAdvertController = async (req: Request, res: Response, next: 
       isSale: updatedAdvert.isSale,
       ownerId: updatedAdvert.ownerId,
       status: updatedAdvert.status,
-      message: 'Anuncio creado con éxito',
+      message: 'Anuncio actualizado con éxito',
     });
   } catch (error) {
     next(error);

--- a/backend/src/controllers/products/updateAdvertController.ts
+++ b/backend/src/controllers/products/updateAdvertController.ts
@@ -1,0 +1,51 @@
+import { NextFunction, Request, Response } from 'express';
+import {
+  EntityNotFoundError,
+  ForbiddenOperationError,
+  UnauthorizedError,
+} from '../../errors/domainError';
+import { updateAdValidator } from './AdvertInputValidator';
+import { Advert } from '../../models/Advert';
+import { User } from '../../models/User';
+
+export const updateAdvertController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    if (!req.user) {
+      throw new UnauthorizedError('Usuario no autenticado');
+    }
+    const { name, description, price, isSale, image, tags } = updateAdValidator.parse(req.body);
+    //TODO: aca va la validacion de la mongoId, pero como la tengo cojo la id sin validar
+    const advertInfoToUpdate = new Advert({
+      name,
+      description,
+      price,
+      isSale,
+      image,
+      tags,
+    });
+
+    const { id } = req.params;
+
+    const advertToUpdate = await Advert.findById(id);
+    if (!advertToUpdate) {
+      throw new EntityNotFoundError('anuncio', 'id');
+    }
+    if (advertToUpdate.ownerId.toString() !== req.user.id) {
+      throw new ForbiddenOperationError('No tiene permisos para editar este anuncio');
+    }
+
+    const updatedAdvert = await Advert.updateOne(id, advertInfoToUpdate);
+
+    res.status(200).json({
+      id: updatedAdvert._id,
+      name: updatedAdvert.name,
+      price: updatedAdvert.price,
+      isSale: updatedAdvert.isSale,
+      ownerId: updatedAdvert.ownerId,
+      status: updatedAdvert.status,
+      message: 'Anuncio creado con éxito',
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/controllers/products/updateAdvertController.ts
+++ b/backend/src/controllers/products/updateAdvertController.ts
@@ -28,9 +28,11 @@ export const updateAdvertController = async (req: Request, res: Response, next: 
     res.status(200).json({
       id: updatedAdvert._id,
       name: updatedAdvert.name,
+      description: updatedAdvert.description,
       price: updatedAdvert.price,
       isSale: updatedAdvert.isSale,
       ownerId: updatedAdvert.ownerId,
+      image: updatedAdvert.image,
       status: updatedAdvert.status,
       message: 'Anuncio actualizado con éxito',
     });

--- a/backend/src/routes/webRoutes.ts
+++ b/backend/src/routes/webRoutes.ts
@@ -1,15 +1,14 @@
 import express from 'express';
 import { createAdvertController } from '../controllers/products/createAdvertController';
-import { getAdsController } from '../controllers/products/getAdsController';
-import { authMiddleware } from '../middlewares/authMiddleware';
-import { updateAdvertController } from '../controllers/products/updateAdvertController';
 import { deleteAdvertController } from '../controllers/products/deleteAdController';
+import { getAdsController } from '../controllers/products/getAdsController';
+import { updateAdvertController } from '../controllers/products/updateAdvertController';
+import { authMiddleware } from '../middlewares/authMiddleware';
 
 export const webRouter = express.Router();
 
 // Product/Ad Routes
 webRouter.post('/', authMiddleware, createAdvertController);
 webRouter.get('/', getAdsController);
-
 webRouter.patch('/:id', authMiddleware, updateAdvertController);
 webRouter.delete('/:id', authMiddleware, deleteAdvertController);

--- a/backend/src/routes/webRoutes.ts
+++ b/backend/src/routes/webRoutes.ts
@@ -2,9 +2,12 @@ import express from 'express';
 import { createAdvertController } from '../controllers/products/createAdvertController';
 import { getAdsController } from '../controllers/products/getAdsController';
 import { authMiddleware } from '../middlewares/authMiddleware';
+import { updateAdvertController } from '../controllers/products/updateAdvertController';
 
 export const webRouter = express.Router();
 
 // Product/Ad Routes
 webRouter.post('/', authMiddleware, createAdvertController);
 webRouter.get('/', getAdsController);
+
+webRouter.patch('/', updateAdvertController);

--- a/backend/src/routes/webRoutes.ts
+++ b/backend/src/routes/webRoutes.ts
@@ -11,5 +11,5 @@ export const webRouter = express.Router();
 webRouter.post('/', authMiddleware, createAdvertController);
 webRouter.get('/', getAdsController);
 
-webRouter.patch('/', authMiddleware, updateAdvertController);
+webRouter.patch('/:id', authMiddleware, updateAdvertController);
 webRouter.delete('/:id', authMiddleware, deleteAdvertController);


### PR DESCRIPTION
## Contexto

Closes #8

---

## Cambios
- Añade endpoint `PATCH /adverts/:id`
- Valida que el usuario esté autenticado
- Valida que solo el propietario pueda editar el anuncio
- Permite actualizar parcialmente los campos del anuncio
- Devuelve la respuesta normalizada para frontend usando `mapAdvertToResponse`

---

## Pruebas
- [x] `npm run build`
- [x] `npm run lint`
- [x] Usuario propietario puede editar su anuncio
- [x] Usuario no propietario no puede editar
- [x] Usuario no autenticado no puede editar