### PR TITLE
fix: redirect authenticated users from auth pages

### DIFF
--- a/frontend/wallaclone/src/pages/LoginPage.tsx
+++ b/frontend/wallaclone/src/pages/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { useState, type SyntheticEvent } from "react";
+import { useState, useEffect, type SyntheticEvent } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import Footer from "../components/layout/Footer";
 import { loginUser } from "../services/authService";
@@ -10,6 +10,13 @@ interface LoginErrors {
 }
 export default function LoginPage() {
     const navigate = useNavigate();
+
+    useEffect(() => {
+        const token = localStorage.getItem("token");
+        if (token) {
+            navigate("/", { replace: true });
+        }
+    }, [navigate]);
 
     const [username, setUsername] = useState("");
     const [password, setPassword] = useState("");
@@ -57,7 +64,7 @@ export default function LoginPage() {
                 JSON.stringify(data.user ?? { username: username.trim() }),
             );
 
-            navigate("/");
+            navigate("/", { replace: true });
 
         } catch (error) {
             setErrors({

--- a/frontend/wallaclone/src/pages/RegisterPage.tsx
+++ b/frontend/wallaclone/src/pages/RegisterPage.tsx
@@ -1,9 +1,18 @@
-import { useState, type ChangeEvent, type SyntheticEvent } from "react";
-import { Link } from "react-router-dom";
+import { useState, useEffect, type ChangeEvent, type SyntheticEvent } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import Footer from "../components/layout/Footer";
 import { registerUser } from "../services/authService";
 
 export default function RegisterPage() {
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        const token = localStorage.getItem("token");
+        if (token) {
+            navigate("/", { replace: true });
+        }
+    }, [navigate]);
+
     const [formData, setFormData] = useState({
         username: "",
         email: "",


### PR DESCRIPTION
## Cambios

- Redirige a Home si un usuario autenticado intenta entrar en login
- Redirige a Home si un usuario autenticado intenta entrar en registro
- Evita volver al formulario de login al usar el botón atrás del navegador

---

## Pruebas

- [x] `npm run build`
- [x] Login redirige correctamente a Home
- [x] Botón atrás no muestra login si hay sesión iniciada
- [x] `/register` redirige a Home si hay sesión iniciada