### PR TITLE
[BE] Ver detalle de un anuncio

### DIFF
--- a/backend/src/controllers/products/getAdvertByIdController.ts
+++ b/backend/src/controllers/products/getAdvertByIdController.ts
@@ -1,0 +1,21 @@
+import type { RequestHandler } from 'express';
+import { EntityNotFoundError } from '../../errors/domainError';
+import { Advert } from '../../models/Advert';
+import { mongoIdValidator } from './AdvertInputValidator';
+import { mapAdvertToResponse } from './advertResponseMapper';
+
+export const getAdvertByIdController: RequestHandler = async (req, res, next) => {
+    try {
+        const { id } = mongoIdValidator.parse(req.params);
+
+        const advert = await Advert.findById(id).populate('ownerId', 'username');
+
+        if (!advert) {
+            throw new EntityNotFoundError('anuncio', id);
+        }
+
+        res.status(200).json(mapAdvertToResponse(advert));
+    } catch (error) {
+        next(error);
+    }
+};

--- a/backend/src/routes/webRoutes.ts
+++ b/backend/src/routes/webRoutes.ts
@@ -4,11 +4,13 @@ import { deleteAdvertController } from '../controllers/products/deleteAdControll
 import { getAdsController } from '../controllers/products/getAdsController';
 import { updateAdvertController } from '../controllers/products/updateAdvertController';
 import { authMiddleware } from '../middlewares/authMiddleware';
+import { getAdvertByIdController } from '../controllers/products/getAdvertByIdController';
 
 export const webRouter = express.Router();
 
 // Product/Ad Routes
 webRouter.post('/', authMiddleware, createAdvertController);
 webRouter.get('/', getAdsController);
+webRouter.get('/:id', getAdvertByIdController);
 webRouter.patch('/:id', authMiddleware, updateAdvertController);
 webRouter.delete('/:id', authMiddleware, deleteAdvertController);


### PR DESCRIPTION
## Contexto

Closes #11

---

## Cambios

- Añade endpoint público para obtener el detalle de un anuncio por id
- Valida el id recibido por params
- Devuelve error si el anuncio no existe
- Reutiliza el mapper de respuesta de anuncios para mantener el contrato con frontend
- Incluye información básica del propietario del anuncio

---

## Endpoint

`GET /adverts/:id`

---

## Pruebas

- [x] `GET /adverts/:id` devuelve el detalle de un anuncio existente
- [x] `GET /adverts?limit=1` sigue devolviendo el listado paginado