### PR TITLE
[FE] - Ver detalle de un anuncio

### DIFF
--- a/frontend/wallaclone/src/App.tsx
+++ b/frontend/wallaclone/src/App.tsx
@@ -3,6 +3,7 @@ import Layout from './components/layout/Layout'
 import HomePage from './pages/HomePage'
 import RegisterPage from './pages/RegisterPage'
 import LoginPage from './pages/LoginPage'
+import AdvertDetailPage from './pages/AdvertDetailPage'
 
 function App() {
   return (
@@ -12,6 +13,7 @@ function App() {
         <Route path="/register" element={<RegisterPage />} />
         <Route element={<Layout />}>
           <Route path="/" element={<HomePage />} />
+          <Route path="/adverts/:advertId" element={<AdvertDetailPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/frontend/wallaclone/src/components/adverts/AdvertCard.tsx
+++ b/frontend/wallaclone/src/components/adverts/AdvertCard.tsx
@@ -1,11 +1,12 @@
+import { Link } from "react-router-dom";
 import type { Advert } from "../../services/advertService";
 
 type AdvertCardProps = {
     advert: Advert;
 };
 
-function getAdvertTypeLabel(isSale: boolean) {
-    return isSale ? "Se vende" : "Se busca";
+function getAdvertTypeLabel() {
+    return "Se vende";
 }
 
 function getAdvertStatusLabel(status: Advert["status"]) {
@@ -43,8 +44,9 @@ function AdvertCard({ advert }: AdvertCardProps) {
                 <div className="flex items-start justify-between gap-3">
                     <div>
                         <p className="text-xs font-semibold uppercase tracking-wide text-[#00bba7]">
-                            {getAdvertTypeLabel(advert.isSale)}
+                            {getAdvertTypeLabel()}
                         </p>
+
                         <h2 className="mt-1 line-clamp-2 text-xl font-bold text-gray-900">
                             {advert.name}
                         </h2>
@@ -87,6 +89,13 @@ function AdvertCard({ advert }: AdvertCardProps) {
                         ))}
                     </div>
                 )}
+
+                <Link
+                    to={`/adverts/${advert.id}`}
+                    className="block w-full rounded-md border border-[#00bba7] px-4 py-2 text-center text-sm font-semibold text-[#00bba7] transition-colors hover:bg-[#00bba7] hover:text-white"
+                >
+                    Ver detalle
+                </Link>
             </div>
         </article>
     );

--- a/frontend/wallaclone/src/components/adverts/AdvertCard.tsx
+++ b/frontend/wallaclone/src/components/adverts/AdvertCard.tsx
@@ -5,10 +5,6 @@ type AdvertCardProps = {
     advert: Advert;
 };
 
-function getAdvertTypeLabel() {
-    return "Se vende";
-}
-
 function getAdvertStatusLabel(status: Advert["status"]) {
     const statusLabels = {
         AVAILABLE: "Disponible",
@@ -25,79 +21,78 @@ function getOwnerName(owner?: Advert["owner"]) {
 
 function AdvertCard({ advert }: AdvertCardProps) {
     return (
-        <article className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md">
-            <div className="h-48 bg-gray-100">
-                {advert.image ? (
-                    <img
-                        src={advert.image}
-                        alt={advert.name}
-                        className="h-full w-full object-cover"
-                    />
-                ) : (
-                    <div className="flex h-full items-center justify-center text-sm text-gray-500">
-                        Sin imagen
-                    </div>
-                )}
-            </div>
-
-            <div className="space-y-4 p-5">
-                <div className="flex items-start justify-between gap-3">
-                    <div>
-                        <p className="text-xs font-semibold uppercase tracking-wide text-[#00bba7]">
-                            {getAdvertTypeLabel()}
-                        </p>
-
-                        <h2 className="mt-1 line-clamp-2 text-xl font-bold text-gray-900">
-                            {advert.name}
-                        </h2>
-                    </div>
-
-                    <span className="rounded-full bg-[#00bba7]/10 px-3 py-1 text-xs font-semibold text-[#009689]">
-                        {getAdvertStatusLabel(advert.status)}
-                    </span>
+        <Link
+            to={`/adverts/${advert.id}`}
+            className="block overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm transition-all hover:-translate-y-1 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[#00bba7] focus:ring-offset-2"
+            aria-label={`Ver detalle de ${advert.name}`}
+        >
+            <article>
+                <div className="h-48 bg-gray-100">
+                    {advert.image ? (
+                        <img
+                            src={advert.image}
+                            alt={advert.name}
+                            className="h-full w-full object-cover"
+                        />
+                    ) : (
+                        <div className="flex h-full items-center justify-center text-sm text-gray-500">
+                            Sin imagen
+                        </div>
+                    )}
                 </div>
 
-                <p className="line-clamp-3 text-sm leading-6 text-gray-600">
-                    {advert.description}
-                </p>
+                <div className="space-y-4 p-5">
+                    <div className="flex items-start justify-between gap-3">
+                        <div>
+                            <p className="text-xs font-semibold uppercase tracking-wide text-[#00bba7]">
+                                Se vende
+                            </p>
 
-                <div className="flex items-end justify-between gap-4">
-                    <div>
-                        <p className="text-xs text-gray-500">Publicado por</p>
-                        <p className="font-medium text-gray-800">
-                            {getOwnerName(advert.owner)}
-                        </p>
+                            <h2 className="mt-1 line-clamp-2 text-xl font-bold text-gray-900">
+                                {advert.name}
+                            </h2>
+                        </div>
+
+                        <span className="rounded-full bg-[#00bba7]/10 px-3 py-1 text-xs font-semibold text-[#009689]">
+                            {getAdvertStatusLabel(advert.status)}
+                        </span>
                     </div>
 
-                    <p className="text-2xl font-bold text-gray-900">
-                        {new Intl.NumberFormat("es-ES", {
-                            style: "currency",
-                            currency: "EUR",
-                        }).format(advert.price)}
+                    <p className="line-clamp-3 text-sm leading-6 text-gray-600">
+                        {advert.description}
                     </p>
-                </div>
 
-                {advert.tags.length > 0 && (
-                    <div className="flex flex-wrap gap-2">
-                        {advert.tags.map((tag) => (
-                            <span
-                                key={tag}
-                                className="rounded-full bg-gray-100 px-3 py-1 text-xs text-gray-600"
-                            >
-                                #{tag}
-                            </span>
-                        ))}
+                    <div className="flex items-end justify-between gap-4">
+                        <div>
+                            <p className="text-xs text-gray-500">Publicado por</p>
+                            <p className="font-medium text-gray-800">
+                                {getOwnerName(advert.owner)}
+                            </p>
+                        </div>
+
+                        <p className="text-2xl font-bold text-gray-900">
+                            {new Intl.NumberFormat("es-ES", {
+                                style: "currency",
+                                currency: "EUR",
+                            }).format(advert.price)}
+                        </p>
                     </div>
-                )}
 
-                <Link
-                    to={`/adverts/${advert.id}`}
-                    className="block w-full rounded-md border border-[#00bba7] px-4 py-2 text-center text-sm font-semibold text-[#00bba7] transition-colors hover:bg-[#00bba7] hover:text-white"
-                >
-                    Ver detalle
-                </Link>
-            </div>
-        </article>
+                    {advert.tags.length > 0 && (
+                        <div className="flex flex-wrap gap-2">
+                            {advert.tags.map((tag) => (
+                                <span
+                                    key={tag}
+                                    className="rounded-full bg-gray-100 px-3 py-1 text-xs text-gray-600"
+                                >
+                                    #{tag}
+                                </span>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            </article>
+        </Link>
     );
 }
 

--- a/frontend/wallaclone/src/pages/AdvertDetailPage.tsx
+++ b/frontend/wallaclone/src/pages/AdvertDetailPage.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { getAdvertById, type Advert } from "../services/advertService";
+
+function getAdvertStatusLabel(status: Advert["status"]) {
+    const statusLabels = {
+        AVAILABLE: "Disponible",
+        RESERVED: "Reservado",
+        SOLD: "Vendido",
+    };
+
+    return statusLabels[status] ?? status;
+}
+
+function getOwnerName(owner?: Advert["owner"]) {
+    return owner?.username ?? "Usuario";
+}
+
+function AdvertDetailPage() {
+    const { advertId } = useParams();
+    const [advert, setAdvert] = useState<Advert | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [errorMessage, setErrorMessage] = useState("");
+
+    useEffect(() => {
+        async function loadAdvert() {
+            if (!advertId) {
+                setErrorMessage("No se ha podido identificar el anuncio");
+                setIsLoading(false);
+                return;
+            }
+
+            try {
+                const data = await getAdvertById(advertId);
+                setAdvert(data);
+            } catch (error) {
+                setErrorMessage(
+                    error instanceof Error
+                        ? error.message
+                        : "No se ha podido cargar el anuncio",
+                );
+            } finally {
+                setIsLoading(false);
+            }
+        }
+
+        loadAdvert();
+    }, [advertId]);
+
+    if (isLoading) {
+        return (
+            <section className="min-h-full bg-gray-50 px-6 py-8">
+                <div className="mx-auto max-w-5xl rounded-2xl border border-gray-200 bg-white p-8 text-center text-gray-600 shadow-sm">
+                    Cargando anuncio...
+                </div>
+            </section>
+        );
+    }
+
+    if (errorMessage || !advert) {
+        return (
+            <section className="min-h-full bg-gray-50 px-6 py-8">
+                <div className="mx-auto max-w-5xl rounded-2xl border border-red-200 bg-red-50 p-8 text-center text-red-700">
+                    <p>{errorMessage || "No se ha podido cargar el anuncio"}</p>
+
+                    <Link
+                        to="/"
+                        className="mt-4 inline-block rounded-md bg-[#00bba7] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#009689]"
+                    >
+                        Volver a anuncios
+                    </Link>
+                </div>
+            </section>
+        );
+    }
+
+    return (
+        <section className="min-h-full bg-gray-50 px-6 py-8">
+            <div className="mx-auto max-w-5xl">
+                <Link
+                    to="/"
+                    className="mb-6 inline-block text-sm font-semibold text-[#00bba7] hover:text-[#009689]"
+                >
+                    Volver a anuncios
+                </Link>
+
+                <article className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+                    <div className="grid gap-0 lg:grid-cols-2">
+                        <div className="bg-gray-100">
+                            {advert.image ? (
+                                <img
+                                    src={advert.image}
+                                    alt={advert.name}
+                                    className="h-full min-h-[320px] w-full object-cover"
+                                />
+                            ) : (
+                                <div className="flex min-h-[320px] items-center justify-center text-sm text-gray-500">
+                                    Sin imagen
+                                </div>
+                            )}
+                        </div>
+
+                        <div className="space-y-6 p-6 lg:p-8">
+                            <div className="flex items-start justify-between gap-4">
+                                <div>
+                                    <p className="text-xs font-semibold uppercase tracking-wide text-[#00bba7]">
+                                        Se vende
+                                    </p>
+
+                                    <h1 className="mt-2 text-3xl font-bold text-gray-900">
+                                        {advert.name}
+                                    </h1>
+                                </div>
+
+                                <span className="rounded-full bg-[#00bba7]/10 px-3 py-1 text-xs font-semibold text-[#009689]">
+                                    {getAdvertStatusLabel(advert.status)}
+                                </span>
+                            </div>
+
+                            <p className="text-4xl font-bold text-gray-900">
+                                {new Intl.NumberFormat("es-ES", {
+                                    style: "currency",
+                                    currency: "EUR",
+                                }).format(advert.price)}
+                            </p>
+
+                            <div>
+                                <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+                                    Descripción
+                                </h2>
+                                <p className="mt-2 whitespace-pre-line text-base leading-7 text-gray-700">
+                                    {advert.description}
+                                </p>
+                            </div>
+
+                            <div>
+                                <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+                                    Publicado por
+                                </h2>
+                                <p className="mt-2 text-base font-semibold text-gray-900">
+                                    {getOwnerName(advert.owner)}
+                                </p>
+                            </div>
+
+                            {advert.tags.length > 0 && (
+                                <div>
+                                    <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+                                        Tags
+                                    </h2>
+
+                                    <div className="mt-3 flex flex-wrap gap-2">
+                                        {advert.tags.map((tag) => (
+                                            <span
+                                                key={tag}
+                                                className="rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-600"
+                                            >
+                                                #{tag}
+                                            </span>
+                                        ))}
+                                    </div>
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                </article>
+            </div>
+        </section>
+    );
+}
+
+export default AdvertDetailPage;

--- a/frontend/wallaclone/src/services/advertService.ts
+++ b/frontend/wallaclone/src/services/advertService.ts
@@ -36,3 +36,18 @@ export async function getLatestAdverts(): Promise<GetAdvertsResponse> {
 
     return data;
 }
+
+export async function getAdvertById(advertId: string): Promise<Advert> {
+    const response = await fetch(`${API_BASE_URL}/adverts/${advertId}`);
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok) {
+        throw new Error(
+            data?.message ?? data?.error ?? "No se ha podido cargar el anuncio",
+        );
+    }
+
+    return data;
+}
+


### PR DESCRIPTION
## Contexto

Closes #60

---

## Cambios

- Añade servicio para cargar el detalle de un anuncio por id
- Añade página de detalle de anuncio
- Añade ruta para el detalle de anuncio
- Permite acceder al detalle pulsando en cualquier parte de la tarjeta
- Muestra nombre, imagen, descripción, precio, autor, estado y tags

---

## Pruebas

- [x] Home muestra las tarjetas correctamente
- [x] Al pulsar una tarjeta se abre el detalle del anuncio
- [x] El detalle carga correctamente al refrescar la URL
- [x] No aparece botón de editar en el listado general