### PR TITLE
fix: set production API URL during frontend deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,8 @@ jobs:
           node-version: 22
 
       - name: Install and build frontend
+        env:
+          VITE_API_BASE_URL: https://wallaclone.gitgirlskcweb19.duckdns.org/api
         run: |
           cd frontend
           npm install


### PR DESCRIPTION
## Qué cambia

Se configura `VITE_API_BASE_URL` durante el build del frontend en el workflow de deploy.

---

## Por qué

En producción, el frontend debe llamar a la API usando el prefijo `/api`, gestionado por Nginx:
https://wallaclone.gitgirlskcweb19.duckdns.org/api


Antes, el build de producción no definía explícitamente `VITE_API_BASE_URL`, por lo que el frontend podía generar llamadas sin `/api`, por ejemplo:
https://wallaclone.gitgirlskcweb19.duckdns.org/adverts


Eso provoca que el listado de anuncios falle en producción.

---

## Cambios realizados

- Se ha añadido `VITE_API_BASE_URL` al paso de build del frontend en `.github/workflows/deploy.yml`.
- No se ha modificado la configuración local
- No se han modificado los services del frontend

---

## Cómo se ha probado

Se ha ejecutado el build del frontend simulando la variable de producción:
```zsh
cd frontend
VITE_API_BASE_URL=https://wallaclone.gitgirlskcweb19.duckdns.org/api npm run build
```

---


## Resultado esperado

Después del deploy, las llamadas del frontend en producción deben ir a:
https://wallaclone.gitgirlskcweb19.duckdns.org/api/adverts

y no a:
https://wallaclone.gitgirlskcweb19.duckdns.org/adverts

---


## Checklist

- [x] El build del frontend pasa correctamente
- [x] El deploy termina sin errores
- [ ] En producción, DevTools muestra llamadas a `/api/adverts`
- [ ] El listado de anuncios carga correctamente en producción

