### PR TITLE
ci: use npm ci for frontend deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,7 @@ jobs:
           VITE_API_BASE_URL: https://wallaclone.gitgirlskcweb19.duckdns.org/api
         run: |
           cd frontend
-          npm install
+          npm ci
           npm run build
 
       - name: Upload dist to server


### PR DESCRIPTION
## Resumen de cambios

Se actualiza el workflow de deploy de producción para usar `npm ci` en la instalación de dependencias del frontend.

## Cambios realizados

- Modificado `.github/workflows/deploy.yml`
- Cambiado el paso de instalación del frontend:
  - Antes: `npm install`
  - Ahora: `npm ci`
- Se mantiene el build del frontend con `npm run build`

## Pruebas

Se probó localmente desde la carpeta `frontend`:
```zsh
npm ci
npm run build
```


## Checklist

- [x] El deploy del frontend usa `npm ci`
- [x] El build del frontend sigue ejecutándose con `npm run build`
- [x] No se modifica el deploy del backend
- [x] No se modifican variables de entorno ni secretos
- [x] No se modifica lógica de negocio

