### PR TITLE
feat: add authenticated member adverts management page

### DIFF
--- a/backend/src/controllers/products/getMyAdvertsController.ts
+++ b/backend/src/controllers/products/getMyAdvertsController.ts
@@ -1,0 +1,39 @@
+import type { RequestHandler } from 'express';
+import { UnauthorizedError } from '../../errors/domainError';
+import { Advert } from '../../models/Advert';
+import { getAdvertsQueryValidator } from './AdvertInputValidator';
+import { mapAdvertToResponse } from './advertResponseMapper';
+
+export const getMyAdvertsController: RequestHandler = async (req, res, next) => {
+    try {
+        if (!req.user) {
+            throw new UnauthorizedError('Usuario no autenticado');
+        }
+
+        const { limit, page } = getAdvertsQueryValidator.parse(req.query);
+
+        const skip = (page - 1) * limit;
+
+        const searchQuery = {
+            ownerId: req.user.id,
+        };
+
+        const [advertList, totalAdverts] = await Promise.all([
+            Advert.find(searchQuery)
+                .sort({ createdAt: -1 })
+                .skip(skip)
+                .limit(limit)
+                .populate('ownerId', 'username'),
+            Advert.countDocuments(searchQuery),
+        ]);
+
+        res.status(200).json({
+            content: advertList.map((advert) => mapAdvertToResponse(advert)),
+            total: totalAdverts,
+            page,
+            limit,
+        });
+    } catch (error) {
+        next(error);
+    }
+};

--- a/backend/src/routes/webRoutes.ts
+++ b/backend/src/routes/webRoutes.ts
@@ -3,6 +3,7 @@ import { createAdvertController } from '../controllers/products/createAdvertCont
 import { deleteAdvertController } from '../controllers/products/deleteAdController';
 import { getAdsController } from '../controllers/products/getAdsController';
 import { getAdvertByIdController } from '../controllers/products/getAdvertByIdController';
+import { getMyAdvertsController } from '../controllers/products/getMyAdvertsController';
 import { updateAdvertController } from '../controllers/products/updateAdvertController';
 import { updateAdvertStatusController } from '../controllers/products/updateAdvertStatusController';
 import { contactSellerController } from '../controllers/products/contactSellerController';
@@ -13,6 +14,7 @@ export const webRouter = express.Router();
 // Product/Ad Routes
 webRouter.post('/', authMiddleware, createAdvertController);
 webRouter.get('/', getAdsController);
+webRouter.get('/me', authMiddleware, getMyAdvertsController);
 webRouter.get('/:id', getAdvertByIdController);
 webRouter.patch('/:id/status', authMiddleware, updateAdvertStatusController);
 webRouter.patch('/:id', authMiddleware, updateAdvertController);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import CreateAdvertPage from "./pages/CreateAdvertPage";
 import AdvertDetailPage from "./pages/AdvertDetailPage";
 import EditAdvertPage from "./pages/EditAdvertPage";
 import MemberAdvertsPage from "./pages/MemberAdvertsPage";
+import MyAdvertsPage from "./pages/MyAdvertsPage";
 
 function App() {
   return (
@@ -20,6 +21,7 @@ function App() {
           <Route path="/adverts/new" element={<CreateAdvertPage />} />
           <Route path="/adverts/:advertId" element={<AdvertDetailPage />} />
           <Route path="/adverts/:advertId/edit" element={<EditAdvertPage />} />
+          <Route path="/my-adverts" element={<MyAdvertsPage />} />
           <Route path="/:username" element={<MemberAdvertsPage />} />
         </Route>
       </Routes>

--- a/frontend/src/pages/MyAdvertsPage.tsx
+++ b/frontend/src/pages/MyAdvertsPage.tsx
@@ -1,0 +1,230 @@
+import { useCallback, useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import AdvertCard from "../components/adverts/AdvertCard";
+import { getMyAdverts, type Advert } from "../services/advertService";
+import { deleteAdvert } from "../services/deleteAdvertService";
+
+const ADVERTS_PER_PAGE = 12;
+
+function MyAdvertsPage() {
+    const navigate = useNavigate();
+
+    const [adverts, setAdverts] = useState<Advert[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [errorMessage, setErrorMessage] = useState("");
+    const [successMessage, setSuccessMessage] = useState("");
+    const [currentPage, setCurrentPage] = useState(1);
+    const [totalAdverts, setTotalAdverts] = useState(0);
+    const [deletingAdvertId, setDeletingAdvertId] = useState<string | null>(null);
+
+    const hasPreviousPage = currentPage > 1;
+    const hasNextPage = currentPage * ADVERTS_PER_PAGE < totalAdverts;
+    const totalPages = Math.ceil(totalAdverts / ADVERTS_PER_PAGE);
+
+    const loadMyAdverts = useCallback(
+        async (pageToLoad = 1) => {
+            const token = localStorage.getItem("token");
+
+            if (!token) {
+                navigate("/login");
+                return;
+            }
+
+            try {
+                setIsLoading(true);
+                setErrorMessage("");
+                setSuccessMessage("");
+
+                const data = await getMyAdverts({
+                    limit: ADVERTS_PER_PAGE,
+                    page: pageToLoad,
+                });
+
+                setAdverts(data.content);
+                setTotalAdverts(data.total);
+                setCurrentPage(data.page);
+            } catch (error) {
+                setErrorMessage(
+                    error instanceof Error
+                        ? error.message
+                        : "No se han podido cargar tus anuncios",
+                );
+            } finally {
+                setIsLoading(false);
+            }
+        },
+        [navigate],
+    );
+
+    useEffect(() => {
+        void loadMyAdverts(1);
+    }, [loadMyAdverts]);
+
+    function handlePreviousPage() {
+        if (!hasPreviousPage) {
+            return;
+        }
+
+        void loadMyAdverts(currentPage - 1);
+    }
+
+    function handleNextPage() {
+        if (!hasNextPage) {
+            return;
+        }
+
+        void loadMyAdverts(currentPage + 1);
+    }
+
+    async function handleDeleteAdvert(advertId: string) {
+        const shouldDelete = window.confirm(
+            "¿Seguro que quieres eliminar este anuncio? Esta acción no se puede deshacer.",
+        );
+
+        if (!shouldDelete) {
+            return;
+        }
+
+        try {
+            setDeletingAdvertId(advertId);
+            setErrorMessage("");
+            setSuccessMessage("");
+
+            await deleteAdvert(advertId);
+
+            const nextTotalAdverts = Math.max(totalAdverts - 1, 0);
+            const shouldGoToPreviousPage =
+                adverts.length === 1 && currentPage > 1 && nextTotalAdverts > 0;
+
+            if (shouldGoToPreviousPage) {
+                await loadMyAdverts(currentPage - 1);
+            } else {
+                setAdverts((currentAdverts) =>
+                    currentAdverts.filter((advert) => advert.id !== advertId),
+                );
+                setTotalAdverts(nextTotalAdverts);
+            }
+
+            setSuccessMessage("Anuncio eliminado correctamente");
+        } catch (error) {
+            setErrorMessage(
+                error instanceof Error
+                    ? error.message
+                    : "No se ha podido eliminar el anuncio",
+            );
+        } finally {
+            setDeletingAdvertId(null);
+        }
+    }
+
+    return (
+        <section className="min-h-full bg-gray-50 px-6 py-8">
+            <div className="mx-auto max-w-7xl">
+                <div className="mb-8 flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+                    <div>
+                        <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+                            Mis anuncios
+                        </h1>
+                        <p className="mt-2 text-base text-gray-600">
+                            Gestiona los anuncios que has publicado
+                        </p>
+                    </div>
+
+                    <Link
+                        to="/adverts/new"
+                        className="inline-flex items-center justify-center rounded-md bg-[#00bba7] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#009689]"
+                    >
+                        Crear anuncio
+                    </Link>
+                </div>
+
+                {successMessage && (
+                    <div className="mb-6 rounded-2xl border border-green-200 bg-green-50 p-4 text-green-700">
+                        {successMessage}
+                    </div>
+                )}
+
+                {isLoading && (
+                    <div className="rounded-2xl border border-gray-200 bg-white p-8 text-center text-gray-600 shadow-sm">
+                        Cargando tus anuncios...
+                    </div>
+                )}
+
+                {!isLoading && errorMessage && (
+                    <div className="rounded-2xl border border-red-200 bg-red-50 p-6 text-center text-red-700">
+                        {errorMessage}
+                    </div>
+                )}
+
+                {!isLoading && !errorMessage && adverts.length === 0 && (
+                    <div className="rounded-2xl border border-gray-200 bg-white p-8 text-center text-gray-600 shadow-sm">
+                        Todavía no has publicado ningún anuncio
+                    </div>
+                )}
+
+                {!isLoading && !errorMessage && adverts.length > 0 && (
+                    <>
+                        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                            {adverts.map((advert) => (
+                                <div key={advert.id} className="space-y-3">
+                                    <AdvertCard advert={advert} />
+
+                                    <div className="grid grid-cols-2 gap-3">
+                                        <Link
+                                            to={`/adverts/${advert.id}/edit`}
+                                            state={{ advert }}
+                                            className="inline-flex items-center justify-center rounded-md bg-[#00bba7] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#009689]"
+                                        >
+                                            Editar
+                                        </Link>
+
+                                        <button
+                                            type="button"
+                                            onClick={() => void handleDeleteAdvert(advert.id)}
+                                            disabled={deletingAdvertId === advert.id}
+                                            className="inline-flex items-center justify-center rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+                                        >
+                                            {deletingAdvertId === advert.id
+                                                ? "Eliminando..."
+                                                : "Eliminar"}
+                                        </button>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+
+                        <div className="mt-8 flex flex-col items-center justify-between gap-4 rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:flex-row">
+                            <p className="text-sm text-gray-600">
+                                Página {currentPage}
+                                {totalPages > 0 ? ` de ${totalPages}` : ""} · {totalAdverts}{" "}
+                                anuncios
+                            </p>
+
+                            <div className="flex gap-3">
+                                <button
+                                    type="button"
+                                    onClick={handlePreviousPage}
+                                    disabled={!hasPreviousPage || isLoading}
+                                    className="rounded-md border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+                                >
+                                    Más recientes
+                                </button>
+
+                                <button
+                                    type="button"
+                                    onClick={handleNextPage}
+                                    disabled={!hasNextPage || isLoading}
+                                    className="rounded-md bg-[#00bba7] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#009689] disabled:cursor-not-allowed disabled:opacity-50"
+                                >
+                                    Más antiguos
+                                </button>
+                            </div>
+                        </div>
+                    </>
+                )}
+            </div>
+        </section>
+    );
+}
+
+export default MyAdvertsPage;

--- a/frontend/src/services/advertService.ts
+++ b/frontend/src/services/advertService.ts
@@ -89,6 +89,39 @@ export async function getAdverts(
     return data;
 }
 
+export type GetMyAdvertsParams = Pick<GetAdvertsParams, "page" | "limit">;
+
+export async function getMyAdverts(
+    params: GetMyAdvertsParams = {},
+): Promise<GetAdvertsResponse> {
+    const token = localStorage.getItem("token");
+
+    if (!token) {
+        throw new Error("No se ha podido validar la sesión");
+    }
+
+    const query = buildAdvertsQuery({
+        page: params.page,
+        limit: params.limit,
+    });
+
+    const response = await fetch(`${API_BASE_URL}/adverts/me?${query}`, {
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    });
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok) {
+        throw new Error(
+            data?.message ?? data?.error ?? "No se han podido cargar tus anuncios",
+        );
+    }
+
+    return data;
+}
+
 export async function getLatestAdverts(): Promise<GetAdvertsResponse> {
     return getAdverts({
         limit: 12,


### PR DESCRIPTION
## Resumen de cambios
Se añade la funcionalidad para que una persona autenticada pueda ver y gestionar sus propios anuncios desde una página privada.

## Cambios realizados
- Añadido endpoint autenticado `GET /adverts/me`
- El endpoint devuelve únicamente los anuncios cuyo `ownerId` coincide con el usuario autenticado
- Añadida ruta frontend `/my-adverts`
- Añadida página `MyAdvertsPage`
- Añadida carga de anuncios propios desde el frontend
- Añadidas acciones de gestión en la página de mis anuncios:
  - Editar anuncio
  - Eliminar anuncio
- Se mantiene la Home como listado público general de anuncios
- Se mantiene la ruta pública de anuncios por miembro `/:username`

## Issues relacionados
Closes #54
Closes #15

## Pruebas
Se probaron las comprobaciones del proyecto:
```zsh
npm run typecheck:backend
npm run build:backend
npm run typecheck:frontend
npm run build:frontend
```


También se verificó manualmente:
- Home `/` sigue mostrando el listado general de anuncios
- La ruta `/my-adverts` redirige a login si no hay sesión
- La ruta `/my-adverts` muestra solo los anuncios de la persona autenticada
- Desde `/my-adverts` se puede acceder a editar un anuncio propio
- Desde `/my-adverts` se puede eliminar un anuncio propio
- El backend sigue validando que solo la persona propietaria pueda editar o eliminar sus anuncios

## Checklist
- [x] El endpoint `GET /adverts/me` requiere autenticación
- [x] El endpoint devuelve solo anuncios del usuario autenticado
- [x] La página `/my-adverts` muestra solo anuncios propios
- [x] La Home sigue mostrando el listado público general
- [x] La página de mis anuncios permite editar anuncios
- [x] La página de mis anuncios permite eliminar anuncios
- [x] El cambio cierra #54
- [x] El cambio cierra #15
