### PR TITLE
feat: add social sharing links to advert detail

### DIFF
--- a/frontend/src/pages/AdvertDetailPage.tsx
+++ b/frontend/src/pages/AdvertDetailPage.tsx
@@ -164,6 +164,19 @@ function AdvertDetailPage() {
         ? "Hola, me interesa este artículo. ¿Sigue disponible?"
         : "Hola, creo que tengo algo que puede encajar contigo. ¿Te interesa?";
 
+    const advertShareText = `Mira este anuncio en Wallaclone: ${advert.name}`;
+    const encodedAdvertShareText = encodeURIComponent(advertShareText);
+    const encodedAdvertShareUrl = encodeURIComponent(window.location.href);
+
+    const twitterShareUrl =
+        "https://twitter.com/intent/tweet" +
+        `?text=${encodedAdvertShareText}` +
+        `&url=${encodedAdvertShareUrl}`;
+    const facebookShareUrl =
+        "https://www.facebook.com/sharer/sharer.php" +
+        `?u=${encodedAdvertShareUrl}` +
+        `&quote=${encodedAdvertShareText}`;
+
     async function handleDeleteAdvert() {
         if (!advert) {
             return;
@@ -354,6 +367,32 @@ function AdvertDetailPage() {
                                     </div>
                                 </div>
                             )}
+
+                            <div className="border-t border-gray-100 pt-6">
+                                <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+                                    Compartir anuncio
+                                </h2>
+
+                                <div className="mt-3 flex flex-wrap gap-3">
+                                    <a
+                                        href={twitterShareUrl}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className="rounded-md bg-black px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-gray-800"
+                                    >
+                                        Compartir en X
+                                    </a>
+
+                                    <a
+                                        href={facebookShareUrl}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700"
+                                    >
+                                        Compartir en Facebook
+                                    </a>
+                                </div>
+                            </div>
 
                             {!canManageAdvert && (
                                 <div className="border-t border-gray-100 pt-6">


### PR DESCRIPTION
## Resumen de cambios
Se añade la opción de compartir un anuncio desde su página de detalle.

## Cambios realizados
- Añadida sección de compartir en la página de detalle del anuncio
- Añadido enlace para compartir en X/Twitter
- Añadido enlace para compartir en Facebook
- Los enlaces usan la URL limpia del anuncio actual
- Se mantiene sin cambios la lógica de backend
- Se mantiene sin cambios la lógica de contacto, edición, eliminación y cambio de estado del anuncio

## Issue relacionado
Closes #21

## Pruebas
Se probaron las comprobaciones del frontend:
```zsh
npm run typecheck:frontend
npm run build:frontend
```

También se verificó manualmente:
- La página de detalle del anuncio sigue cargando correctamente
- Se muestra la sección “Compartir anuncio”
- El botón de X/Twitter abre una pestaña nueva para compartir el anuncio
- El botón de Facebook abre una pestaña nueva para compartir el anuncio
- En local, Facebook puede no mostrar preview completa porque no puede leer URLs de `localhost`
- La funcionalidad no afecta a editar, eliminar, contactar ni cambiar estado del anuncio

## Checklist
- [x] Se puede compartir un anuncio en X/Twitter
- [x] Se puede compartir un anuncio en Facebook
- [x] Los enlaces usan la URL del anuncio actual
- [x] La página de detalle sigue funcionando correctamente
- [x] El cambio cierra #21

