### PR TITLE
feat: add user account update flow

### DIFF
--- a/backend/src/controllers/authentication/authBodyValidator.ts
+++ b/backend/src/controllers/authentication/authBodyValidator.ts
@@ -10,3 +10,26 @@ export const authLoginValidator = zod.object({
   username: zod.string().trim().min(1),
   password: zod.string().min(6).max(64),
 });
+
+export const updateUserValidator = zod
+  .object({
+    username: zod.string().trim().min(1).optional(),
+    email: zod.string().trim().toLowerCase().pipe(zod.email()).optional(),
+    currentPassword: zod.string().min(6).max(64).optional(),
+    newPassword: zod.string().min(6).max(64).optional(),
+  })
+  .refine(
+    ({ username, email, newPassword }) =>
+      username !== undefined || email !== undefined || newPassword !== undefined,
+    {
+      error: 'Debes enviar al menos un dato para actualizar',
+    },
+  )
+  .refine(
+    ({ currentPassword, newPassword }) =>
+      newPassword === undefined || currentPassword !== undefined,
+    {
+      error: 'Debes indicar tu contraseña actual para cambiarla',
+      path: ['currentPassword'],
+    },
+  );

--- a/backend/src/controllers/authentication/updateUserController.ts
+++ b/backend/src/controllers/authentication/updateUserController.ts
@@ -1,0 +1,86 @@
+import type { RequestHandler } from 'express';
+import {
+    BusinessConflictError,
+    EntityNotFoundError,
+    UnauthorizedError,
+} from '../../errors/domainError';
+import { User } from '../../models/User';
+import { updateUserValidator } from './authBodyValidator';
+import { securityService } from './securityService';
+
+export const updateUserController: RequestHandler = async (req, res, next) => {
+    try {
+        if (!req.user) {
+            throw new UnauthorizedError('Usuario no autenticado');
+        }
+
+        const { username, email, currentPassword, newPassword } =
+            updateUserValidator.parse(req.body);
+
+        const userToUpdate = await User.findById(req.user.id).select('+password');
+
+        if (!userToUpdate) {
+            throw new EntityNotFoundError('usuario', req.user.id);
+        }
+
+        if (username && username !== userToUpdate.username) {
+            const existingUsername = await User.findOne({
+                username,
+                _id: { $ne: req.user.id },
+            });
+
+            if (existingUsername) {
+                throw new BusinessConflictError(
+                    `El nombre de usuario ${username} está en uso`,
+                );
+            }
+
+            userToUpdate.username = username;
+        }
+
+        if (email && email !== userToUpdate.email) {
+            const existingEmail = await User.findOne({
+                email,
+                _id: { $ne: req.user.id },
+            });
+
+            if (existingEmail) {
+                throw new BusinessConflictError('Ya existe un usuario con este email');
+            }
+
+            userToUpdate.email = email;
+        }
+
+        if (newPassword) {
+            if (!currentPassword) {
+                throw new UnauthorizedError(
+                    'Debes indicar tu contraseña actual para poder actualizarla',
+                );
+            }
+
+            if (!userToUpdate.password) {
+                throw new UnauthorizedError('No se ha podido validar la contraseña');
+            }
+
+            await securityService.comparePasswords(
+                currentPassword,
+                userToUpdate.password,
+            );
+
+            userToUpdate.password = await securityService.hashPassword(newPassword);
+        }
+
+        const updatedUser = await userToUpdate.save();
+
+        res.status(200).json({
+            user: {
+                id: updatedUser._id,
+                username: updatedUser.username,
+                email: updatedUser.email,
+            },
+            message: 'Datos de usuario actualizados correctamente',
+        });
+    } catch (error) {
+        next(error);
+    }
+};

--- a/backend/src/routes/authenticationRoutes.ts
+++ b/backend/src/routes/authenticationRoutes.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { signupController } from '../controllers/authentication/signupController';
 import { loginController } from '../controllers/authentication/loginController';
 import { logoutController } from '../controllers/authentication/logoutController';
+import { updateUserController } from '../controllers/authentication/updateUserController';
 import { authMiddleware } from '../middlewares/authMiddleware';
 
 export const authenticationRouter = express.Router();
@@ -10,3 +11,4 @@ export const authenticationRouter = express.Router();
 authenticationRouter.post('/register', signupController);
 authenticationRouter.post('/login', loginController);
 authenticationRouter.post('/logout', authMiddleware, logoutController);
+authenticationRouter.patch('/me', authMiddleware, updateUserController);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import CreateAdvertPage from "./pages/CreateAdvertPage";
 import AdvertDetailPage from "./pages/AdvertDetailPage";
 import EditAdvertPage from "./pages/EditAdvertPage";
 import MemberAdvertsPage from "./pages/MemberAdvertsPage";
+import AccountPage from "./pages/AccountPage";
 
 function App() {
   return (
@@ -17,6 +18,7 @@ function App() {
 
         <Route element={<Layout />}>
           <Route path="/" element={<HomePage />} />
+          <Route path="/account" element={<AccountPage />} />
           <Route path="/adverts/new" element={<CreateAdvertPage />} />
           <Route path="/adverts/:advertId" element={<AdvertDetailPage />} />
           <Route path="/adverts/:advertId/edit" element={<EditAdvertPage />} />

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -45,6 +45,13 @@ function Header() {
                                 Crear anuncio
                             </Link>
 
+                            <Link
+                                to="/account"
+                                className="rounded-md bg-[#00bba7] px-4 py-2 text-white hover:bg-[#009689]"
+                            >
+                                Mi cuenta
+                            </Link>
+
                             <button
                                 type="button"
                                 onClick={handleLogout}

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -1,0 +1,418 @@
+import { useEffect, useState, type SyntheticEvent } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import {
+    updateUser,
+    type AuthUser,
+    type UpdateUserPayload,
+} from "../services/authService";
+
+type AccountErrors = {
+    username?: string;
+    email?: string;
+    currentPassword?: string;
+    newPassword?: string;
+    confirmNewPassword?: string;
+    general?: string;
+};
+
+function getStoredUser() {
+    const storedUser = localStorage.getItem("user");
+
+    if (!storedUser) {
+        return null;
+    }
+
+    try {
+        return JSON.parse(storedUser) as AuthUser;
+    } catch {
+        return null;
+    }
+}
+
+function AccountPage() {
+    const navigate = useNavigate();
+
+    const [username, setUsername] = useState("");
+    const [email, setEmail] = useState("");
+    const [currentPassword, setCurrentPassword] = useState("");
+    const [newPassword, setNewPassword] = useState("");
+    const [confirmNewPassword, setConfirmNewPassword] = useState("");
+
+    const [errors, setErrors] = useState<AccountErrors>({});
+    const [successMessage, setSuccessMessage] = useState("");
+    const [isLoading, setIsLoading] = useState(false);
+
+    useEffect(() => {
+        const token = localStorage.getItem("token");
+
+        if (!token) {
+            navigate("/login", { replace: true });
+            return;
+        }
+
+        const currentUser = getStoredUser();
+
+        if (currentUser) {
+            setUsername(currentUser.username ?? "");
+            setEmail(currentUser.email ?? "");
+        }
+    }, [navigate]);
+
+    const validate = () => {
+        const newErrors: AccountErrors = {};
+
+        const trimmedUsername = username.trim();
+        const trimmedEmail = email.trim();
+        const trimmedCurrentPassword = currentPassword.trim();
+        const trimmedNewPassword = newPassword.trim();
+        const trimmedConfirmNewPassword = confirmNewPassword.trim();
+
+        if (!trimmedUsername) {
+            newErrors.username = "El nombre de usuario es obligatorio";
+        }
+
+        if (!trimmedEmail) {
+            newErrors.email = "El email es obligatorio";
+        } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) {
+            newErrors.email = "Introduce un email válido";
+        }
+
+        const isChangingPassword =
+            Boolean(trimmedCurrentPassword) ||
+            Boolean(trimmedNewPassword) ||
+            Boolean(trimmedConfirmNewPassword);
+
+        if (isChangingPassword) {
+            if (!trimmedCurrentPassword) {
+                newErrors.currentPassword =
+                    "Indica tu contraseña actual para cambiarla";
+            } else if (trimmedCurrentPassword.length < 6) {
+                newErrors.currentPassword =
+                    "La contraseña actual debe tener al menos 6 caracteres";
+            } else if (trimmedCurrentPassword.length > 64) {
+                newErrors.currentPassword =
+                    "La contraseña actual no puede tener más de 64 caracteres";
+            }
+
+            if (!trimmedNewPassword) {
+                newErrors.newPassword = "Indica la nueva contraseña";
+            } else if (trimmedNewPassword.length < 6) {
+                newErrors.newPassword =
+                    "La nueva contraseña debe tener al menos 6 caracteres";
+            } else if (trimmedNewPassword.length > 64) {
+                newErrors.newPassword =
+                    "La nueva contraseña no puede tener más de 64 caracteres";
+            }
+
+            if (!trimmedConfirmNewPassword) {
+                newErrors.confirmNewPassword = "Confirma la nueva contraseña";
+            } else if (trimmedNewPassword !== trimmedConfirmNewPassword) {
+                newErrors.confirmNewPassword = "Las contraseñas no coinciden";
+            }
+        }
+
+        setErrors(newErrors);
+        return Object.keys(newErrors).length === 0;
+    };
+
+    async function handleSubmit(event: SyntheticEvent<HTMLFormElement>) {
+        event.preventDefault();
+
+        if (!validate()) {
+            return;
+        }
+
+        const storedUser = getStoredUser();
+
+        const trimmedUsername = username.trim();
+        const trimmedEmail = email.trim().toLowerCase();
+        const trimmedCurrentPassword = currentPassword.trim();
+        const trimmedNewPassword = newPassword.trim();
+
+        const payload: UpdateUserPayload = {};
+
+        if (trimmedUsername !== storedUser?.username) {
+            payload.username = trimmedUsername;
+        }
+
+        if (trimmedEmail !== storedUser?.email) {
+            payload.email = trimmedEmail;
+        }
+
+        if (trimmedNewPassword) {
+            payload.currentPassword = trimmedCurrentPassword;
+            payload.newPassword = trimmedNewPassword;
+        }
+
+        if (Object.keys(payload).length === 0) {
+            setErrors({
+                general: "No has cambiado ningún dato",
+            });
+            setSuccessMessage("");
+            return;
+        }
+
+        try {
+            setIsLoading(true);
+            setErrors({});
+            setSuccessMessage("");
+
+            const data = await updateUser(payload);
+
+            localStorage.setItem("user", JSON.stringify(data.user));
+
+            setUsername(data.user.username ?? "");
+            setEmail(data.user.email ?? "");
+            setCurrentPassword("");
+            setNewPassword("");
+            setConfirmNewPassword("");
+            setSuccessMessage(data.message);
+        } catch (error) {
+            setErrors({
+                general:
+                    error instanceof Error
+                        ? error.message
+                        : "No se han podido actualizar tus datos",
+            });
+        } finally {
+            setIsLoading(false);
+        }
+    }
+
+    return (
+        <section className="min-h-full bg-gray-50 px-6 py-8">
+            <div className="mx-auto max-w-3xl">
+                <Link
+                    to="/"
+                    className="mb-6 inline-block text-sm font-semibold text-[#00bba7] hover:text-[#009689]"
+                >
+                    Volver a anuncios
+                </Link>
+
+                <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm lg:p-8">
+                    <div className="mb-8">
+                        <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+                            Mi cuenta
+                        </h1>
+                        <p className="mt-2 text-base text-gray-600">
+                            Actualiza tus datos de usuario y contraseña
+                        </p>
+                    </div>
+
+                    {successMessage && (
+                        <div className="mb-6 rounded-md border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
+                            {successMessage}
+                        </div>
+                    )}
+
+                    {errors.general && (
+                        <div className="mb-6 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                            {errors.general}
+                        </div>
+                    )}
+
+                    <form onSubmit={handleSubmit} className="space-y-6">
+                        <div>
+                            <label
+                                htmlFor="username"
+                                className="block text-sm font-semibold text-gray-700"
+                            >
+                                Nombre de usuario
+                            </label>
+
+                            <input
+                                id="username"
+                                type="text"
+                                value={username}
+                                onChange={(event) => {
+                                    setUsername(event.target.value);
+                                    setErrors((currentErrors) => ({
+                                        ...currentErrors,
+                                        username: undefined,
+                                        general: undefined,
+                                    }));
+                                    setSuccessMessage("");
+                                }}
+                                disabled={isLoading}
+                                className={`mt-2 w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#00bba7] disabled:cursor-not-allowed disabled:bg-gray-100 ${errors.username ? "border-red-500" : "border-gray-300"
+                                    }`}
+                                placeholder="Tu nombre de usuario"
+                            />
+
+                            {errors.username && (
+                                <p className="mt-2 text-sm text-red-600">{errors.username}</p>
+                            )}
+                        </div>
+
+                        <div>
+                            <label
+                                htmlFor="email"
+                                className="block text-sm font-semibold text-gray-700"
+                            >
+                                Email
+                            </label>
+
+                            <input
+                                id="email"
+                                type="email"
+                                value={email}
+                                onChange={(event) => {
+                                    setEmail(event.target.value);
+                                    setErrors((currentErrors) => ({
+                                        ...currentErrors,
+                                        email: undefined,
+                                        general: undefined,
+                                    }));
+                                    setSuccessMessage("");
+                                }}
+                                disabled={isLoading}
+                                className={`mt-2 w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#00bba7] disabled:cursor-not-allowed disabled:bg-gray-100 ${errors.email ? "border-red-500" : "border-gray-300"
+                                    }`}
+                                placeholder="tu@email.com"
+                            />
+
+                            {errors.email && (
+                                <p className="mt-2 text-sm text-red-600">{errors.email}</p>
+                            )}
+                        </div>
+
+                        <div className="border-t border-gray-100 pt-6">
+                            <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+                                Cambiar contraseña
+                            </h2>
+
+                            <p className="mt-2 text-sm text-gray-600">
+                                Si no quieres cambiarla, deja estos campos vacíos.
+                            </p>
+
+                            <div className="mt-5 space-y-5">
+                                <div>
+                                    <label
+                                        htmlFor="currentPassword"
+                                        className="block text-sm font-semibold text-gray-700"
+                                    >
+                                        Contraseña actual
+                                    </label>
+
+                                    <input
+                                        id="currentPassword"
+                                        type="password"
+                                        value={currentPassword}
+                                        onChange={(event) => {
+                                            setCurrentPassword(event.target.value);
+                                            setErrors((currentErrors) => ({
+                                                ...currentErrors,
+                                                currentPassword: undefined,
+                                                general: undefined,
+                                            }));
+                                            setSuccessMessage("");
+                                        }}
+                                        disabled={isLoading}
+                                        minLength={6}
+                                        maxLength={64}
+                                        className={`mt-2 w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#00bba7] disabled:cursor-not-allowed disabled:bg-gray-100 ${errors.currentPassword
+                                                ? "border-red-500"
+                                                : "border-gray-300"
+                                            }`}
+                                        placeholder="Tu contraseña actual"
+                                    />
+
+                                    {errors.currentPassword && (
+                                        <p className="mt-2 text-sm text-red-600">
+                                            {errors.currentPassword}
+                                        </p>
+                                    )}
+                                </div>
+
+                                <div>
+                                    <label
+                                        htmlFor="newPassword"
+                                        className="block text-sm font-semibold text-gray-700"
+                                    >
+                                        Nueva contraseña
+                                    </label>
+
+                                    <input
+                                        id="newPassword"
+                                        type="password"
+                                        value={newPassword}
+                                        onChange={(event) => {
+                                            setNewPassword(event.target.value);
+                                            setErrors((currentErrors) => ({
+                                                ...currentErrors,
+                                                newPassword: undefined,
+                                                confirmNewPassword: undefined,
+                                                general: undefined,
+                                            }));
+                                            setSuccessMessage("");
+                                        }}
+                                        disabled={isLoading}
+                                        minLength={6}
+                                        maxLength={64}
+                                        className={`mt-2 w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#00bba7] disabled:cursor-not-allowed disabled:bg-gray-100 ${errors.newPassword ? "border-red-500" : "border-gray-300"
+                                            }`}
+                                        placeholder="Nueva contraseña"
+                                    />
+
+                                    {errors.newPassword && (
+                                        <p className="mt-2 text-sm text-red-600">
+                                            {errors.newPassword}
+                                        </p>
+                                    )}
+                                </div>
+
+                                <div>
+                                    <label
+                                        htmlFor="confirmNewPassword"
+                                        className="block text-sm font-semibold text-gray-700"
+                                    >
+                                        Confirmar nueva contraseña
+                                    </label>
+
+                                    <input
+                                        id="confirmNewPassword"
+                                        type="password"
+                                        value={confirmNewPassword}
+                                        onChange={(event) => {
+                                            setConfirmNewPassword(event.target.value);
+                                            setErrors((currentErrors) => ({
+                                                ...currentErrors,
+                                                confirmNewPassword: undefined,
+                                                general: undefined,
+                                            }));
+                                            setSuccessMessage("");
+                                        }}
+                                        disabled={isLoading}
+                                        minLength={6}
+                                        maxLength={64}
+                                        className={`mt-2 w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#00bba7] disabled:cursor-not-allowed disabled:bg-gray-100 ${errors.confirmNewPassword
+                                                ? "border-red-500"
+                                                : "border-gray-300"
+                                            }`}
+                                        placeholder="Repite la nueva contraseña"
+                                    />
+
+                                    {errors.confirmNewPassword && (
+                                        <p className="mt-2 text-sm text-red-600">
+                                            {errors.confirmNewPassword}
+                                        </p>
+                                    )}
+                                </div>
+                            </div>
+                        </div>
+
+                        <button
+                            type="submit"
+                            disabled={isLoading}
+                            className="w-full rounded-md bg-[#00bba7] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#009689] disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                            {isLoading ? "Guardando cambios..." : "Guardar cambios"}
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </section>
+    );
+}
+
+export default AccountPage;

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -11,7 +11,7 @@ type LoginUserData = {
     password: string;
 };
 
-type AuthUser = {
+export type AuthUser = {
     id?: string;
     username: string;
     email?: string;
@@ -27,6 +27,18 @@ type LoginResponse = {
     message?: string;
     token: string;
     user?: AuthUser;
+};
+
+export type UpdateUserPayload = {
+    username?: string;
+    email?: string;
+    currentPassword?: string;
+    newPassword?: string;
+};
+
+type UpdateUserResponse = {
+    message: string;
+    user: AuthUser;
 };
 
 export async function registerUser(
@@ -90,4 +102,33 @@ export async function logoutUser(token: string): Promise<void> {
             data?.message ?? data?.error ?? "No se ha podido cerrar la sesión",
         );
     }
+}
+
+export async function updateUser(
+    userData: UpdateUserPayload,
+): Promise<UpdateUserResponse> {
+    const token = localStorage.getItem("token");
+
+    if (!token) {
+        throw new Error("No se ha podido validar la sesión");
+    }
+
+    const response = await fetch(`${API_BASE_URL}/auth/me`, {
+        method: "PATCH",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(userData),
+    });
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok) {
+        throw new Error(
+            data?.message ?? data?.error ?? "No se han podido actualizar tus datos",
+        );
+    }
+
+    return data;
 }


### PR DESCRIPTION
## Resumen de cambios
Se añade la funcionalidad para que una persona autenticada pueda actualizar sus datos desde la zona privada de cuenta.

## Cambios realizados

- Añadido endpoint autenticado `PATCH /auth/me`
- Añadida validación para actualizar username, email y contraseña
- Añadida comprobación para impedir usar un username ya existente
- Añadida comprobación para impedir usar un email ya existente
- Añadida verificación de contraseña actual antes de permitir cambiar la contraseña
- Añadida página privada `/account`
- Añadido formulario para actualizar datos de usuario
- Añadida actualización de `localStorage.user` tras guardar cambios
- Añadido enlace “Mi cuenta” en el header cuando hay sesión iniciada

## Issues relacionados
Closes #52
Closes #17

## Pruebas
Se probaron las comprobaciones del proyecto:
```zsh
npm run typecheck:backend
npm run build:backend
npm run typecheck:frontend
npm run build:frontend
```

También se verificó manualmente:
- Sin sesión, `/account` redirige a login
- Con sesión, `/account` muestra el formulario de cuenta
- Se puede actualizar el username usando uno libre
- Se puede actualizar el email usando uno libre
- No se puede actualizar el username si ya está en uso
- No se puede actualizar el email si ya está en uso
- Se puede cambiar la contraseña indicando la contraseña actual correcta
- No se puede cambiar la contraseña si la contraseña actual es incorrecta
- Tras actualizar datos, se actualiza `localStorage.user`

## Checklist
- [x] Solo usuarios autenticados pueden actualizar sus datos
- [x] No se permite usar un username ya existente
- [x] No se permite usar un email ya existente
- [x] Se puede cambiar contraseña con contraseña actual correcta
- [x] No se puede cambiar contraseña sin validar la contraseña actual
- [x] La página `/account` está protegida
- [x] El cambio cierra #52 
- [x] El cambio cierra #17
